### PR TITLE
DCS-706: fix failing integration test

### DIFF
--- a/integration-tests/integration/videolink/courtVideoLinkBookingsPage.spec.js
+++ b/integration-tests/integration/videolink/courtVideoLinkBookingsPage.spec.js
@@ -120,7 +120,7 @@ context('A user can view the video link home page', () => {
   it('Has correct date format and returns unsupported courts when Other is selected', () => {
     cy.visit('/bookings')
     const courtVideoBookingsPage = CourtVideoLinkBookingsPage.verifyOnPage()
-    courtVideoBookingsPage.dateInput().should('have.value', Cypress.moment().format('D MMMM YYYY'))
+    courtVideoBookingsPage.dateInput().should('have.value', Cypress.moment().format('DD MMMM YYYY'))
     courtVideoBookingsPage.courtOption().select('Other')
     courtVideoBookingsPage.submitButton().click()
 


### PR DESCRIPTION
Integration test was failing because it expected a leading zero days less than 10. 
In T3, the dates appear like below so test code updated to format with a leading zero
<img width="300" alt="Screenshot 2020-12-09 at 09 00 20" src="https://user-images.githubusercontent.com/50441412/101608526-b9b3a780-39fd-11eb-9b45-be13116a129f.png">
