### PR TITLE
DCS-763 Remove manual setting of display name

### DIFF
--- a/backend/routes/index.ts
+++ b/backend/routes/index.ts
@@ -10,11 +10,7 @@ import viewBookingsRoutes from './viewBookings'
 const router = express.Router()
 
 export = function createRoutes(services: Services): Router {
-  router.get('/', (req, res) => {
-    res.render('courtsVideolink.njk', {
-      user: { displayName: req.session.userDetails.name },
-    })
-  })
+  router.get('/', (req, res) => res.render('courtsVideolink.njk'))
 
   router.use(createBookingRoutes(services))
   router.use(changeBookingRoutes(services))

--- a/backend/routes/requestBooking/index.ts
+++ b/backend/routes/requestBooking/index.ts
@@ -39,15 +39,7 @@ export default function createRoutes({ notifyApi, whereaboutsApi, oauthApi, pris
     asyncMiddleware(createBookingRequest)
   )
   routes.get('/confirmation', withRetryLink('/request-booking/confirmation'), asyncMiddleware(confirm))
-  routes.get(
-    '/prisoner-not-listed',
-    asyncMiddleware(async (req, res) => {
-      return res.render('requestBooking/prisonerNotListed.njk', {
-        url: req.originalUrl,
-        user: { displayName: req.session.userDetails.name },
-      })
-    })
-  )
+  routes.get('/prisoner-not-listed', (req, res) => res.render('requestBooking/prisonerNotListed.njk'))
 
   const router = express.Router({ mergeParams: true })
   router.use('/request-booking', routes)

--- a/backend/routes/requestBooking/requestBooking.js
+++ b/backend/routes/requestBooking/requestBooking.js
@@ -86,7 +86,6 @@ const requestBookingFactory = ({ logError, notifyApi, whereaboutsApi, oauthApi, 
       value: prison.agencyId,
     }))
     return res.render('requestBooking/requestBooking.njk', {
-      user: { displayName: req.session.userDetails.name },
       prisons: prisonDropdownValues,
     })
   }
@@ -131,7 +130,6 @@ const requestBookingFactory = ({ logError, notifyApi, whereaboutsApi, oauthApi, 
         value: p.agencyId,
       }))
       return res.render('requestBooking/requestBooking.njk', {
-        user: { displayName: req.session.userDetails.name },
         errors,
         prisons: prisonDropdownValues,
         formValues: req.body,
@@ -353,7 +351,6 @@ const requestBookingFactory = ({ logError, notifyApi, whereaboutsApi, oauthApi, 
     )
 
     return res.render('requestBooking/requestBookingConfirmation.njk', {
-      user: { displayName: req.session.userDetails.name },
       title: 'The video link has been requested',
       details: {
         prison,

--- a/backend/routes/viewBookings/viewCourtBookingsController.ts
+++ b/backend/routes/viewBookings/viewCourtBookingsController.ts
@@ -5,9 +5,6 @@ import BookingService from '../../services/bookingService'
 export = (bookingService: BookingService): RequestHandler => async (req, res) => {
   const { date, courtOption } = req.query as { date: string; courtOption?: string }
   const searchDate = date ? moment(date as string, 'D MMMM YYYY') : moment()
-  const user = {
-    displayName: req.session.userDetails.name,
-  }
 
   const { appointments, courts } = await bookingService.getAppointmentList(res.locals, searchDate, courtOption)
 
@@ -17,7 +14,6 @@ export = (bookingService: BookingService): RequestHandler => async (req, res) =>
     courts: [...courts.map(key => ({ value: key, text: key })), { value: 'Other', text: 'Other' }],
     courtOption,
     appointments,
-    user,
     date: searchDate,
     title: courtOption ? `${title} - ${courtOption}` : title,
     hearingDescriptions: { PRE: 'Pre-court hearing', MAIN: 'Court hearing', POST: 'Post-court hearing' },

--- a/backend/tests/requestBooking.test.js
+++ b/backend/tests/requestBooking.test.js
@@ -71,9 +71,6 @@ describe('Request a booking', () => {
             value: 'WWI',
           },
         ],
-        user: {
-          displayName: 'Test User',
-        },
       })
     })
 
@@ -655,7 +652,6 @@ describe('Request a booking', () => {
           courtLocation: 'London',
         },
         title: 'The video link has been requested',
-        user: { displayName: 'Test User' },
       })
     })
 

--- a/backend/tests/viewCourtBookings.test.ts
+++ b/backend/tests/viewCourtBookings.test.ts
@@ -52,7 +52,6 @@ describe('View court bookings', () => {
           { value: 'Southwark', text: 'Southwark' },
           { value: 'Other', text: 'Other' },
         ],
-        user: { displayName: 'Test User' },
         hearingDescriptions: {
           MAIN: 'Court hearing',
           POST: 'Post-court hearing',
@@ -88,7 +87,6 @@ describe('View court bookings', () => {
           { value: 'Southwark', text: 'Southwark' },
           { value: 'Other', text: 'Other' },
         ],
-        user: { displayName: 'Test User' },
         hearingDescriptions: {
           MAIN: 'Court hearing',
           POST: 'Post-court hearing',
@@ -128,7 +126,6 @@ describe('View court bookings', () => {
           { value: 'Southwark', text: 'Southwark' },
           { value: 'Other', text: 'Other' },
         ],
-        user: { displayName: 'Test User' },
         hearingDescriptions: {
           MAIN: 'Court hearing',
           POST: 'Post-court hearing',


### PR DESCRIPTION
Display name is set up in res.locals in middleware so doesn't need to be specified everywhere