### PR TITLE
Dcs 777 change dates to long form

### DIFF
--- a/backend/middleware/checkAvailability.test.js
+++ b/backend/middleware/checkAvailability.test.js
@@ -1,6 +1,6 @@
 const moment = require('moment')
 const checkAvailability = require('./checkAvailability')
-const { DAY_MONTH_YEAR, DATE_TIME_FORMAT_SPEC } = require('../shared/dateHelpers')
+const { DAY_LONG_MONTH_YEAR, DATE_TIME_FORMAT_SPEC } = require('../shared/dateHelpers')
 
 const existingEventsService = {}
 const availableSlotsService = {}
@@ -37,7 +37,7 @@ const appointmentDetails = {
     { value: 2, text: 'Room 2' },
     { value: 3, text: 'Room 3' },
   ],
-  date: '01/01/2017',
+  date: '01 January 2017',
   preAppointmentRequired: 'yes',
   postAppointmentRequired: 'yes',
   court: 'Leeds',
@@ -86,7 +86,7 @@ describe('Room check middleware', () => {
       const tomorrow = moment().add(1, 'day')
       req.body = {
         bookingId: 1,
-        date: tomorrow.format(DAY_MONTH_YEAR),
+        date: tomorrow.format(DAY_LONG_MONTH_YEAR),
         startTimeHours: '00',
         startTimeMinutes: '01',
         endTimeHours: '00',
@@ -106,7 +106,7 @@ describe('Room check middleware', () => {
     beforeEach(() => {
       req.body = {
         bookingId,
-        date: moment().format(DAY_MONTH_YEAR),
+        date: moment().format(DAY_LONG_MONTH_YEAR),
         preAppointmentRequired: 'yes',
         postAppointmentRequired: 'yes',
       }

--- a/backend/routes/amendBooking/changeDateAndTimeController.test.ts
+++ b/backend/routes/amendBooking/changeDateAndTimeController.test.ts
@@ -83,7 +83,7 @@ describe('change date and time controller', () => {
       expect(res.render).toHaveBeenCalledWith('amendBooking/changeDateAndTime.njk', {
         bookingId: 123,
         changeTime: true,
-        date: '20/11/2020',
+        date: moment('2020-11-20T18:00:00', 'YYYY-MM-DDTHH:mm:ss'),
         locations: { court: 'City of London', prison: 'some prison' },
         prisoner: { name: 'John Doe' },
       })

--- a/backend/routes/amendBooking/changeDateAndTimeController.ts
+++ b/backend/routes/amendBooking/changeDateAndTimeController.ts
@@ -1,6 +1,5 @@
 import { RequestHandler } from 'express'
 import type BookingService from '../../services/bookingService'
-import { DAY_MONTH_YEAR } from '../../shared/dateHelpers'
 
 export = class ChangeDateAndTimeController {
   public constructor(private readonly bookingService: BookingService) {}
@@ -11,7 +10,7 @@ export = class ChangeDateAndTimeController {
       const bookingDetails = await this.bookingService.get(res.locals, parseInt(bookingId, 10))
       res.render('amendBooking/changeDateAndTime.njk', {
         changeTime: changeTimeView,
-        date: changeTimeView ? bookingDetails.date.format(DAY_MONTH_YEAR) : null,
+        date: changeTimeView ? bookingDetails.date : null,
         bookingId,
         prisoner: {
           name: bookingDetails.prisonerName,

--- a/backend/routes/createBooking/startController.js
+++ b/backend/routes/createBooking/startController.js
@@ -1,5 +1,10 @@
 const moment = require('moment')
-const { DAY_MONTH_YEAR, DATE_TIME_FORMAT_SPEC, buildDateTime } = require('../../shared/dateHelpers')
+const {
+  DAY_MONTH_YEAR,
+  DAY_LONG_MONTH_YEAR,
+  DATE_TIME_FORMAT_SPEC,
+  buildDateTime,
+} = require('../../shared/dateHelpers')
 const { formatName } = require('../../utils')
 
 module.exports = ({ prisonApi }) => {
@@ -17,17 +22,18 @@ module.exports = ({ prisonApi }) => {
     } = fields
     const errors = []
     const now = moment()
-    const isToday = date ? moment(date, DAY_MONTH_YEAR).isSame(now, 'day') : false
+    const isToday = date ? moment(date, DAY_LONG_MONTH_YEAR).isSame(now, 'day') : false
 
     const startTimeDuration = moment.duration(now.diff(startTime))
     const endTimeDuration = endTime && moment.duration(startTime.diff(endTime))
 
     if (!date) errors.push({ text: 'Select the date of the video link', href: '#date' })
 
-    if (date && !moment(date, DAY_MONTH_YEAR).isValid())
-      errors.push({ text: 'Enter a date in DD/MM/YYYY format', href: '#date' })
+    if (date && !moment(date, DAY_LONG_MONTH_YEAR, true).isValid()) {
+      errors.push({ text: 'Enter a date in D MMMM YYYY format', href: '#date' })
+    }
 
-    if (date && moment(date, DAY_MONTH_YEAR).isBefore(now, 'day'))
+    if (date && moment(date, DAY_LONG_MONTH_YEAR, true).isBefore(now, 'day'))
       errors.push({ text: 'Select a date that is not in the past', href: '#date' })
 
     if (!startTimeHours && !startTimeMinutes)

--- a/backend/routes/createBooking/startController.test.js
+++ b/backend/routes/createBooking/startController.test.js
@@ -133,7 +133,7 @@ describe('Add court appointment', () => {
       })
 
       it('should return an error when selected date is in the past', async () => {
-        req.body = { date: '28/03/2019' }
+        req.body = { date: '28 March 2019' }
         await controller.validateInput(req, res)
 
         expect(res.render).toHaveBeenCalledWith(
@@ -145,7 +145,7 @@ describe('Add court appointment', () => {
       })
 
       it('should return an error when selected start time is in the past', async () => {
-        req.body = { date: '29/03/2019', startTimeHours: '10', startTimeMinutes: '0' }
+        req.body = { date: '29 March 2019', startTimeHours: '10', startTimeMinutes: '0' }
         await controller.validateInput(req, res)
 
         expect(res.render).toHaveBeenCalledWith(
@@ -161,7 +161,7 @@ describe('Add court appointment', () => {
 
     it('should return an error when the end time is before the start time', async () => {
       req.body = {
-        date: '29/03/2019',
+        date: '29 March 2019',
         startTimeHours: '10',
         startTimeMinutes: '15',
         endTimeHours: '09',

--- a/backend/routes/requestBooking/requestBooking.js
+++ b/backend/routes/requestBooking/requestBooking.js
@@ -1,5 +1,5 @@
 const moment = require('moment')
-const { buildDateTime, DATE_TIME_FORMAT_SPEC, DAY_MONTH_YEAR, Time } = require('../../shared/dateHelpers')
+const { buildDateTime, DATE_TIME_FORMAT_SPEC, DAY_LONG_MONTH_YEAR, Time } = require('../../shared/dateHelpers')
 const { validateComments } = require('../../shared/appointmentConstants')
 const {
   notifications: { requestBookingCourtTemplateVLBAdminId, requestBookingCourtTemplateRequesterId, emails: emailConfig },
@@ -11,7 +11,7 @@ const isValidNumber = number => Number.isSafeInteger(Number.parseInt(number, 10)
 
 const validateStartEndTime = ({ date, startTimeHours, startTimeMinutes, endTimeHours, endTimeMinutes, errors }) => {
   const now = moment()
-  const isToday = date ? moment(date, DAY_MONTH_YEAR).isSame(now, 'day') : false
+  const isToday = date ? moment(date, DAY_LONG_MONTH_YEAR).isSame(now, 'day') : false
   const startTime = buildDateTime({ date, hours: startTimeHours, minutes: startTimeMinutes })
   const endTime = buildDateTime({ date, hours: endTimeHours, minutes: endTimeMinutes })
   const startTimeDuration = startTime && moment.duration(now.diff(startTime))
@@ -40,14 +40,13 @@ const validateDate = (date, errors) => {
   const now = moment()
   if (!date) errors.push({ text: 'Select the date of the video link', href: '#date' })
 
-  if (date && !moment(date, DAY_MONTH_YEAR).isValid())
+  if (date && !moment(date, DAY_LONG_MONTH_YEAR, true).isValid())
     errors.push({
-      text:
-        'Enter the date of the video link using numbers in the format of day, month and year separated using a forward slash',
+      text: 'Enter the date of the video link using numbers in the format of "day month year" e.g. 13 January 2021',
       href: '#date',
     })
 
-  if (date && moment(date, DAY_MONTH_YEAR).isBefore(now, 'day'))
+  if (date && moment(date, DAY_LONG_MONTH_YEAR, true).isBefore(now, 'day'))
     errors.push({ text: 'Select a date that is not in the past', href: '#date' })
 }
 const extractObjectFromFlash = ({ req, key }) =>
@@ -190,7 +189,7 @@ const requestBookingFactory = ({ logError, notifyApi, whereaboutsApi, oauthApi, 
         prison: matchingPrison.fromattedDescription || matchingPrison.description,
       },
       hearingDetails: {
-        date: moment(date, DAY_MONTH_YEAR).format('D MMMM YYYY'),
+        date,
         courtHearingStartTime: Time(startTime),
         courtHearingEndTime: Time(endTime),
       },
@@ -286,7 +285,7 @@ const requestBookingFactory = ({ logError, notifyApi, whereaboutsApi, oauthApi, 
       firstName,
       lastName,
       dateOfBirth: dateOfBirth.format('D MMMM YYYY'),
-      date: moment(date, DAY_MONTH_YEAR).format('dddd D MMMM YYYY'),
+      date: moment(date, DAY_LONG_MONTH_YEAR).format('dddd D MMMM YYYY'),
       startTime: Time(startTime),
       endTime: endTime && Time(endTime),
       prison: matchingPrison.formattedDescription || matchingPrison.description,

--- a/backend/services/bookingService.ts
+++ b/backend/services/bookingService.ts
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import { Appointment, NewAppointment } from 'whereaboutsApi'
-import { DATE_TIME_FORMAT_SPEC, Time } from '../shared/dateHelpers'
+import { DATE_TIME_FORMAT_SPEC, Time, DAY_LONG_MONTH_YEAR } from '../shared/dateHelpers'
 import { formatName } from '../utils'
 import type WhereaboutsApi from '../api/whereaboutsApi'
 import type PrisonApi from '../api/prisonApi'
@@ -62,7 +62,7 @@ export = class BookingService {
       prisonName: agencyDetails.description,
       agencyId: agencyDetails.agencyId,
       courtLocation: bookingDetails.court,
-      dateDescription: moment(bookingDetails.main.startTime, DATE_TIME_FORMAT_SPEC).format('D MMMM YYYY'),
+      dateDescription: moment(bookingDetails.main.startTime, DATE_TIME_FORMAT_SPEC).format(DAY_LONG_MONTH_YEAR),
       date: moment(bookingDetails.main.startTime, DATE_TIME_FORMAT_SPEC),
       comments: bookingDetails.comment,
       ...(bookingDetails.pre ? { preDetails: toAppointmentDetails(bookingDetails.pre) } : {}),

--- a/backend/shared/dateHelpers.js
+++ b/backend/shared/dateHelpers.js
@@ -3,6 +3,7 @@ const moment = require('moment')
 const DATE_TIME_FORMAT_SPEC = 'YYYY-MM-DDTHH:mm:ss'
 const DATE_ONLY_FORMAT_SPEC = 'YYYY-MM-DD'
 const DAY_MONTH_YEAR = 'DD/MM/YYYY'
+const DAY_LONG_MONTH_YEAR = 'D MMMM YYYY'
 const MOMENT_DAY_OF_THE_WEEK = 'dddd'
 const MOMENT_TIME = 'HH:mm'
 
@@ -29,6 +30,7 @@ module.exports = {
   DATE_TIME_FORMAT_SPEC,
   DATE_ONLY_FORMAT_SPEC,
   DAY_MONTH_YEAR,
+  DAY_LONG_MONTH_YEAR,
   MOMENT_DAY_OF_THE_WEEK,
   MOMENT_TIME,
   DayOfTheWeek,

--- a/backend/tests/dateHelpers.test.js
+++ b/backend/tests/dateHelpers.test.js
@@ -2,12 +2,12 @@ const { buildDateTime, DATE_TIME_FORMAT_SPEC } = require('../shared/dateHelpers'
 
 describe('Date helpers', () => {
   it('should return a valid date time with 0 as hours and minutes', () => {
-    const dateTime = buildDateTime({ date: '2010-12-10', hours: 0, minutes: 0 })
+    const dateTime = buildDateTime({ date: '20 October 2012', hours: 0, minutes: 0 })
     expect(dateTime.format(DATE_TIME_FORMAT_SPEC)).toEqual('2012-10-20T00:00:00')
   })
 
   it('should return a valid date time with strings as params ', () => {
-    const dateTime = buildDateTime({ date: '2010-12-10', hours: '00', minutes: '00' })
+    const dateTime = buildDateTime({ date: '20 October 2012', hours: '00', minutes: '00' })
     expect(dateTime.format(DATE_TIME_FORMAT_SPEC)).toEqual('2012-10-20T00:00:00')
   })
 

--- a/backend/tests/requestBooking.test.js
+++ b/backend/tests/requestBooking.test.js
@@ -9,7 +9,7 @@ process.env.WANDSWORTH_VLB_EMAIL = 'test@justice.gov.uk'
 const config = require('../config')
 
 const { requestBookingFactory } = require('../routes/requestBooking/requestBooking')
-const { DAY_MONTH_YEAR } = require('../shared/dateHelpers')
+const { DAY_LONG_MONTH_YEAR } = require('../shared/dateHelpers')
 const { notifyApi } = require('../api/notifyApi')
 const { raiseAnalyticsEvent } = require('../raiseAnalyticsEvent')
 
@@ -93,14 +93,14 @@ describe('Request a booking', () => {
       it('should stash the appointment details and redirect to offender details', async () => {
         jest.spyOn(Date, 'now').mockImplementation(() => 1553860800000) // Friday 2019-03-29T12:00:00.000Z
 
-        req.body = { ...validBody, date: moment().format(DAY_MONTH_YEAR) }
+        req.body = { ...validBody, date: moment().format(DAY_LONG_MONTH_YEAR) }
 
         await controller.checkAvailability(req, res)
 
         expect(req.flash).toHaveBeenCalledWith(
           'requestBooking',
           expect.objectContaining({
-            date: '29/03/2019',
+            date: '29 March 2019',
             prison: 'test@test',
             startTime: '2019-03-29T22:05:00',
             endTime: '2019-03-29T23:05:00',
@@ -117,7 +117,7 @@ describe('Request a booking', () => {
 
       it('should validate and check for missing required fields', async () => {
         jest.spyOn(Date, 'now').mockImplementation(() => 1553860800000) // Friday 2019-03-29T12:00:00.000Z
-        const date = moment().format(DAY_MONTH_YEAR)
+        const date = moment().format(DAY_LONG_MONTH_YEAR)
 
         req.body = {
           date,
@@ -149,7 +149,7 @@ describe('Request a booking', () => {
       })
 
       it('should return validation messages for start times being in the past', async () => {
-        const date = moment().format(DAY_MONTH_YEAR)
+        const date = moment().format(DAY_LONG_MONTH_YEAR)
         const startTime = moment().subtract(5, 'minutes')
         const startTimeHours = startTime.hour()
         const startTimeMinutes = startTime.minute()
@@ -174,7 +174,7 @@ describe('Request a booking', () => {
 
       it('should validate that the end time comes after the start time', async () => {
         req.body = {
-          date: moment().format(DAY_MONTH_YEAR),
+          date: moment().format(DAY_LONG_MONTH_YEAR),
           startTimeHours: '23',
           startTimeMinutes: '00',
           endTimeHours: '22',
@@ -196,7 +196,7 @@ describe('Request a booking', () => {
 
     it('should validate full start and end time', async () => {
       jest.spyOn(Date, 'now').mockImplementation(() => 1553860800000) // Friday 2019-03-29T12:00:00.000Z
-      const date = moment().format(DAY_MONTH_YEAR)
+      const date = moment().format(DAY_LONG_MONTH_YEAR)
 
       req.body = {
         prison: 'WWI',
@@ -256,7 +256,7 @@ describe('Request a booking', () => {
       })
       req.flash.mockImplementation(() => [
         {
-          date: '01/01/2019',
+          date: '01 January 2019',
           startTime: '2919-01-01T10:00:00',
           endTime: '2019-01-01T11:00:00',
           prison: 'WWI',
@@ -348,7 +348,7 @@ describe('Request a booking', () => {
         return key !== 'errors'
           ? [
               {
-                date: '01/01/3019',
+                date: '01 January 3019',
                 startTime: '3019-01-01T01:00:00',
                 endTime: '3019-01-01T02:00:00',
                 prison: 'WWI',
@@ -416,7 +416,7 @@ describe('Request a booking', () => {
 
     it('should validate missing offender details', async () => {
       const bookingDetails = {
-        date: '01/01/3019',
+        date: '01 January 3019',
         startTime: '3019-01-01T01:00:00',
         endTime: '3019-01-01T02:00:00',
         prison: 'WWI',
@@ -505,7 +505,7 @@ describe('Request a booking', () => {
     it('should submit two emails, one for the prison and another for the current user', async () => {
       req.flash.mockImplementation(() => [
         {
-          date: '01/01/2019',
+          date: '01 January 2019',
           startTime: '2919-01-01T10:00:00',
           endTime: '2019-01-01T11:00:00',
           prison: 'WWI',
@@ -566,7 +566,7 @@ describe('Request a booking', () => {
     it('should stash appointment details and redirect to the confirmation page', async () => {
       req.flash.mockImplementation(() => [
         {
-          date: '01/01/2019',
+          date: '01 January 2019',
           startTime: '2919-01-01T10:00:00',
           endTime: '2019-01-01T11:00:00',
           prison: 'WWI',

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -1,7 +1,7 @@
 const moment = require('moment')
-const { DATE_TIME_FORMAT_SPEC } = require('./shared/dateHelpers')
+const { DATE_TIME_FORMAT_SPEC, DAY_LONG_MONTH_YEAR } = require('./shared/dateHelpers')
 
-const switchDateFormat = (displayDate, fromFormat = 'DD/MM/YYYY') => {
+const switchDateFormat = (displayDate, fromFormat = DAY_LONG_MONTH_YEAR) => {
   if (displayDate) {
     return moment(displayDate, fromFormat).format('YYYY-MM-DD')
   }

--- a/integration-tests/integration/bookings/amendBooking.spec.js
+++ b/integration-tests/integration/bookings/amendBooking.spec.js
@@ -212,7 +212,7 @@ context('A user can amend a booking', () => {
     cy.task('stubLoginCourt')
     ChangeTimePage.goTo(10)
     const changeTimePage = ChangeTimePage.verifyOnPage()
-    changeTimePage.date().should('have.value', '02/01/2020')
+    changeTimePage.date().should('have.value', '2 January 2020')
   })
 
   it('A user will be navigated to the booking-details page', () => {

--- a/integration-tests/integration/bookings/createBooking.spec.js
+++ b/integration-tests/integration/bookings/createBooking.spec.js
@@ -124,7 +124,7 @@ context('A user can add a video link', () => {
     cy.task('stubLoginCourt')
     const startPage = StartPage.verifyOnPage()
     const addAppointmentForm = startPage.form()
-    addAppointmentForm.date().type(moment().add(1, 'days').format('DD/MM/YYYY'))
+    addAppointmentForm.date().type(moment().add(1, 'days').format('DD MMMM YYYY'))
 
     startPage.activeDate().click()
     addAppointmentForm.startTimeHours().select('10')
@@ -257,7 +257,7 @@ context('A user can add a video link', () => {
 
     const startPage = StartPage.verifyOnPage()
     const addAppointmentForm = startPage.form()
-    addAppointmentForm.date().type(tomorrow.format('DD/MM/YYYY'))
+    addAppointmentForm.date().type(tomorrow.format('DD MMMM YYYY'))
 
     startPage.activeDate().click()
     addAppointmentForm.startTimeHours().select('10')
@@ -339,7 +339,7 @@ context('A user can add a video link', () => {
 
     const startPage = StartPage.verifyOnPage()
     const addAppointmentForm = startPage.form()
-    addAppointmentForm.date().type(tomorrow.format('DD/MM/YYYY'))
+    addAppointmentForm.date().type(tomorrow.format('DD MMMM YYYY'))
 
     startPage.activeDate().click()
     addAppointmentForm.startTimeHours().select('10')

--- a/integration-tests/integration/bookings/requestBooking.spec.js
+++ b/integration-tests/integration/bookings/requestBooking.spec.js
@@ -25,7 +25,7 @@ context('A user can request a booking', () => {
   it('A user can request a video link booking for a prisoner who is not in prison', () => {
     const startPage = StartPage.verifyOnPage()
     const startForm = startPage.form()
-    startForm.date().type(moment().add(1, 'days').format('DD/MM/YYYY'))
+    startForm.date().type(moment().add(1, 'days').format('DD MMMM YYYY'))
     startForm.prison().select('WWI')
     startForm.startTimeHours().select('10')
     startForm.startTimeMinutes().select('00')

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
   },
   "scripts": {
     "clean": " rm -Rf build dist .nyc_output coverage test-results",
-    "copy-views": "cp -R views dist/",
-    "copy-assets": "cp -R static/ build/",
+    "copy-views": "mkdir -p dist && cp -R views dist/",
+    "copy-assets": "cp -R static/. build/",
     "watch-views": "nodemon --watch views -e html,njk -x npm run copy-views",
     "watch-assets": "nodemon --watch static -e css,js,woff,png -x npm run copy-assets",
     "watch-ts": "tsc -w",

--- a/views/components/datePicker/datePicker.scss
+++ b/views/components/datePicker/datePicker.scss
@@ -11,7 +11,7 @@
 }
 
 .date-picker-container {
-    width: 150px;
+    width: 210px;
     margin-bottom: 32px;
 }
 

--- a/views/components/dateTimeAndCourtBriefingPicker/dateTimeAndCourtBriefingPicker.njk
+++ b/views/components/dateTimeAndCourtBriefingPicker/dateTimeAndCourtBriefingPicker.njk
@@ -14,9 +14,9 @@
                     id: 'date',
                     label: 'Date',
                     name: 'date',
-                    date: params.date,
+                    date: params.date | formatDate('D MMMM YYYY'),
                     errorMessage: errors | findError('date'),
-                    attributes: {'data-disable-past-date':'true', 'data-add-appointment-date': 'true'}
+                    attributes: {"date-format": "d MM yy", 'data-disable-past-date':'true', 'data-add-appointment-date': 'true'}
                 }) }}
 
 


### PR DESCRIPTION
This ticket has been put on hold because the overall concept of date format needs a broader rethink. 

The ticket was to change the date display from short form to long form, eg 12/08/2021 to 12 August 2021.
Although the changes made have achieved this, some failing tests suggest that some functionalities, such as saving dates to flash, may not have been sufficiently covered. Additionally there is a lack of comprehensive testing.

The pages that are impacted by the date format are 
/add-court-appointment 
/select-court
/request-booking
/change-time

The strategy for changing the date display was to alter the views/components/dateTimeAndCourtBriefingPicker/dateTimeAndCourtBriefingPicker.njk macro so that it could accept a moment object rather than a date as a string. The macro would then call the njk fllter  | formatDate(“D MMM YYYY) to convert the moment object to a string in the form 12 August 2021. The controller for each of the above pages would correspondingly provide a moment rather than a string. 
