### PR TITLE
DCS-813 Ignore current booking when calculating availability during update

### DIFF
--- a/backend/routes/amendBooking/changeDateAndTimeController.ts
+++ b/backend/routes/amendBooking/changeDateAndTimeController.ts
@@ -57,18 +57,15 @@ export default class ChangeDateAndTimeController {
 
       const { agencyId } = await this.bookingService.get(res.locals, parseInt(bookingId, 10))
 
-      const { isAvailable } = await this.availabilityCheckService.getAvailability(
-        res.locals,
-        {
-          agencyId,
-          date: form.date,
-          startTime: form.startTime,
-          endTime: form.endTime,
-          preRequired: form.preAppointmentRequired,
-          postRequired: form.postAppointmentRequired,
-        },
-        parseInt(bookingId, 10)
-      )
+      const { isAvailable } = await this.availabilityCheckService.getAvailability(res.locals, {
+        agencyId,
+        videoBookingId: parseInt(bookingId, 10),
+        date: form.date,
+        startTime: form.startTime,
+        endTime: form.endTime,
+        preRequired: form.preAppointmentRequired,
+        postRequired: form.postAppointmentRequired,
+      })
 
       setUpdate(res, form)
 

--- a/backend/routes/amendBooking/selectAvailableRoomsController.test.ts
+++ b/backend/routes/amendBooking/selectAvailableRoomsController.test.ts
@@ -130,18 +130,15 @@ describe('Select available rooms controller', () => {
 
         await controller.view()(req, res, null)
 
-        expect(availabilityCheckService.getAvailability).toHaveBeenCalledWith(
-          res.locals,
-          {
-            agencyId: 'WWI',
-            date: moment('2020-11-20T00:00:00', DATE_TIME_FORMAT_SPEC, true),
-            startTime: moment('2020-11-20T18:00:00', DATE_TIME_FORMAT_SPEC, true),
-            endTime: moment('2020-11-20T19:00:00', DATE_TIME_FORMAT_SPEC, true),
-            postRequired: true,
-            preRequired: true,
-          },
-          123
-        )
+        expect(availabilityCheckService.getAvailability).toHaveBeenCalledWith(res.locals, {
+          agencyId: 'WWI',
+          videoBookingId: 123,
+          date: moment('2020-11-20T00:00:00', DATE_TIME_FORMAT_SPEC, true),
+          startTime: moment('2020-11-20T18:00:00', DATE_TIME_FORMAT_SPEC, true),
+          endTime: moment('2020-11-20T19:00:00', DATE_TIME_FORMAT_SPEC, true),
+          postRequired: true,
+          preRequired: true,
+        })
       })
     })
 
@@ -229,6 +226,25 @@ describe('Select available rooms controller', () => {
       req.params.bookingId = '12'
 
       return expect(() => controller.submit()(req, res, null)).rejects.toThrow('Appointment is no longer available')
+    })
+
+    it('should make final availability check before performing update', async () => {
+      bookingService.get.mockResolvedValue(bookingDetails)
+      availabilityCheckService.getAvailability.mockResolvedValue(availableLocations)
+
+      req.params.bookingId = '12'
+
+      await controller.submit()(req, res, null)
+
+      expect(availabilityCheckService.getAvailability).toHaveBeenCalledWith(res.locals, {
+        agencyId: 'WWI',
+        videoBookingId: 12,
+        date: moment('2020-11-20T00:00:00', DATE_TIME_FORMAT_SPEC, true),
+        startTime: moment('2020-11-20T18:00:00', DATE_TIME_FORMAT_SPEC, true),
+        endTime: moment('2020-11-20T19:00:00', DATE_TIME_FORMAT_SPEC, true),
+        postRequired: true,
+        preRequired: true,
+      })
     })
 
     it('should submit perform an update', async () => {

--- a/backend/routes/amendBooking/selectAvailableRoomsController.ts
+++ b/backend/routes/amendBooking/selectAvailableRoomsController.ts
@@ -25,18 +25,15 @@ export default class SelectAvailableRoomsController {
 
       const form = input ? RoomAndComment(input) : { comment: bookingDetails.comments }
 
-      const { rooms } = await this.availabilityCheckService.getAvailability(
-        res.locals,
-        {
-          agencyId: bookingDetails.agencyId,
-          date: update.date,
-          startTime: update.startTime,
-          endTime: update.endTime,
-          preRequired: update.preAppointmentRequired,
-          postRequired: update.postAppointmentRequired,
-        },
-        parseInt(bookingId, 10)
-      )
+      const { rooms } = await this.availabilityCheckService.getAvailability(res.locals, {
+        agencyId: bookingDetails.agencyId,
+        videoBookingId: parseInt(bookingId, 10),
+        date: update.date,
+        startTime: update.startTime,
+        endTime: update.endTime,
+        preRequired: update.preAppointmentRequired,
+        postRequired: update.postAppointmentRequired,
+      })
 
       return res.render('amendBooking/selectAvailableRooms.njk', {
         errors,
@@ -66,6 +63,7 @@ export default class SelectAvailableRoomsController {
 
       const { isAvailable } = await this.availabilityCheckService.getAvailability(res.locals, {
         agencyId: bookingDetails.agencyId,
+        videoBookingId: parseInt(bookingId, 10),
         date: update.date,
         startTime: update.startTime,
         endTime: update.endTime,

--- a/backend/services/availabilityCheckService.test.ts
+++ b/backend/services/availabilityCheckService.test.ts
@@ -32,7 +32,7 @@ describe('AvailabilityCheckService', () => {
   const videoBookingId = 123
   describe('Get available rooms', () => {
     const getAvailableRooms = async params => {
-      const availability = await service.getAvailability(context, params, videoBookingId)
+      const availability = await service.getAvailability(context, params)
       return availability.rooms
     }
     it('No rooms', async () => {
@@ -44,6 +44,7 @@ describe('AvailabilityCheckService', () => {
 
       const rooms = await getAvailableRooms({
         agencyId: 'WWI',
+        videoBookingId,
         date: moment('20/11/2020', DAY_MONTH_YEAR),
         startTime: moment('2020-11-20T14:00:00', DATE_TIME_FORMAT_SPEC),
         endTime: moment('2020-11-20T14:30:00', DATE_TIME_FORMAT_SPEC),
@@ -76,6 +77,7 @@ describe('AvailabilityCheckService', () => {
 
       const rooms = await getAvailableRooms({
         agencyId: 'WWI',
+        videoBookingId,
         date: moment('20/11/2020', DAY_MONTH_YEAR),
         startTime: moment('2020-11-20T14:00:00', DATE_TIME_FORMAT_SPEC),
         endTime: moment('2020-11-20T14:30:00', DATE_TIME_FORMAT_SPEC),
@@ -108,6 +110,7 @@ describe('AvailabilityCheckService', () => {
 
       const rooms = await getAvailableRooms({
         agencyId: 'WWI',
+        videoBookingId,
         date: moment('20/11/2020', DAY_MONTH_YEAR),
         startTime: moment('2020-11-20T14:00:00', DATE_TIME_FORMAT_SPEC),
         endTime: moment('2020-11-20T14:30:00', DATE_TIME_FORMAT_SPEC),
@@ -139,6 +142,7 @@ describe('AvailabilityCheckService', () => {
 
       const rooms = await getAvailableRooms({
         agencyId: 'WWI',
+        videoBookingId,
         date: moment('20/11/2020', DAY_MONTH_YEAR),
         startTime: moment('2020-11-20T14:00:00', DATE_TIME_FORMAT_SPEC),
         endTime: moment('2020-11-20T14:30:00', DATE_TIME_FORMAT_SPEC),
@@ -171,6 +175,7 @@ describe('AvailabilityCheckService', () => {
 
       const rooms = await getAvailableRooms({
         agencyId: 'WWI',
+        videoBookingId,
         date: moment('20/11/2020', DAY_MONTH_YEAR),
         startTime: moment('2020-11-20T14:00:00', DATE_TIME_FORMAT_SPEC),
         endTime: moment('2020-11-20T14:30:00', DATE_TIME_FORMAT_SPEC),
@@ -203,6 +208,7 @@ describe('AvailabilityCheckService', () => {
 
       const rooms = await getAvailableRooms({
         agencyId: 'WWI',
+        videoBookingId,
         date: moment('20/11/2020', DAY_MONTH_YEAR),
         startTime: moment('2020-11-20T14:00:00', DATE_TIME_FORMAT_SPEC),
         endTime: moment('2020-11-20T14:30:00', DATE_TIME_FORMAT_SPEC),
@@ -235,6 +241,7 @@ describe('AvailabilityCheckService', () => {
 
       const rooms = await getAvailableRooms({
         agencyId: 'WWI',
+        videoBookingId,
         date: moment('20/11/2020', DAY_MONTH_YEAR),
         startTime: moment('2020-11-20T14:00:00', DATE_TIME_FORMAT_SPEC),
         endTime: moment('2020-11-20T14:30:00', DATE_TIME_FORMAT_SPEC),
@@ -323,6 +330,7 @@ describe('AvailabilityCheckService', () => {
   describe('is available', () => {
     const request = {
       agencyId: 'WWI',
+      videoBookingId,
       date: moment('20/11/2020', DAY_MONTH_YEAR),
       startTime: moment('2020-11-20T14:00:00', DATE_TIME_FORMAT_SPEC),
       endTime: moment('2020-11-20T14:30:00', DATE_TIME_FORMAT_SPEC),
@@ -331,7 +339,7 @@ describe('AvailabilityCheckService', () => {
     }
 
     const isAvailable = async params => {
-      const availability = await service.getAvailability(context, params, videoBookingId)
+      const availability = await service.getAvailability(context, params)
       return availability.isAvailable
     }
 
@@ -658,18 +666,15 @@ describe('AvailabilityCheckService', () => {
         post: [location(1), location(2), location(3)],
       })
 
-      const result = await service.getAvailability(
-        context,
-        {
-          agencyId: 'WWI',
-          date: moment('20/11/2020', DAY_MONTH_YEAR),
-          startTime: moment('2020-11-20T14:00:00', DATE_TIME_FORMAT_SPEC),
-          endTime: moment('2020-11-20T14:30:00', DATE_TIME_FORMAT_SPEC),
-          preRequired: true,
-          postRequired: true,
-        },
-        videoBookingId
-      )
+      const result = await service.getAvailability(context, {
+        agencyId: 'WWI',
+        videoBookingId,
+        date: moment('20/11/2020', DAY_MONTH_YEAR),
+        startTime: moment('2020-11-20T14:00:00', DATE_TIME_FORMAT_SPEC),
+        endTime: moment('2020-11-20T14:30:00', DATE_TIME_FORMAT_SPEC),
+        preRequired: true,
+        postRequired: true,
+      })
 
       expect(result.isAvailable).toBe(true)
 
@@ -693,7 +698,7 @@ describe('AvailabilityCheckService', () => {
     })
 
     const getInterval = async params => {
-      const availability = await service.getAvailability(context, params, videoBookingId)
+      const availability = await service.getAvailability(context, params)
       return availability.totalInterval
     }
 

--- a/backend/services/availabilityCheckService.ts
+++ b/backend/services/availabilityCheckService.ts
@@ -18,12 +18,8 @@ export default class AvailabilityCheckService {
     return { value: location.locationId, text: location.description }
   }
 
-  public async getAvailability(
-    context: Context,
-    request: AvailabilityRequest,
-    videoBookingId?: number
-  ): Promise<RoomAvailability> {
-    const { agencyId, date, startTime, endTime, preRequired, postRequired } = request
+  public async getAvailability(context: Context, request: AvailabilityRequest): Promise<RoomAvailability> {
+    const { agencyId, videoBookingId, date, startTime, endTime, preRequired, postRequired } = request
 
     const { pre, main, post } = await this.whereaboutsApi.getAvailableRooms(context, {
       agencyId,

--- a/backend/services/model.ts
+++ b/backend/services/model.ts
@@ -9,6 +9,7 @@ export type Room = {
 }
 export type AvailabilityRequest = {
   agencyId: string
+  videoBookingId?: number
   date: Moment
   startTime: Moment
   endTime: Moment

--- a/integration-tests/integration/bookings/amendBooking/amendBooking.spec.js
+++ b/integration-tests/integration/bookings/amendBooking/amendBooking.spec.js
@@ -192,27 +192,6 @@ context('A user can amend a booking', () => {
 
     const selectAvailableRoomsPage = SelectAvailableRoomsPage.verifyOnPage()
 
-    cy.task('getFindAvailabilityRequests').then(request => {
-      expect(request).to.deep.equal([
-        {
-          agencyId: 'WWI',
-          date: tomorrow.format('YYYY-MM-DD'),
-          vlbIdsToExclude: [10],
-          preInterval: { start: '10:35', end: '10:55' },
-          mainInterval: { start: '10:55', end: '11:55' },
-          postInterval: { start: '11:55', end: '12:15' },
-        },
-        {
-          agencyId: 'WWI',
-          date: tomorrow.format('YYYY-MM-DD'),
-          vlbIdsToExclude: [10],
-          preInterval: { start: '10:35', end: '10:55' },
-          mainInterval: { start: '10:55', end: '11:55' },
-          postInterval: { start: '11:55', end: '12:15' },
-        },
-      ])
-    })
-
     const selectAvailableRoomsForm = selectAvailableRoomsPage.form()
     selectAvailableRoomsForm.preLocation().select('100')
     selectAvailableRoomsForm.mainLocation().select('110')
@@ -234,6 +213,38 @@ context('A user can amend a booking', () => {
     confirmationPage.exitToAllBookings().click()
 
     CourtVideoLinkBookingsPage.verifyOnPage()
+
+    cy.task('getFindAvailabilityRequests').then(request => {
+      expect(request).to.deep.equal([
+        // Initial availability check
+        {
+          agencyId: 'WWI',
+          date: tomorrow.format('YYYY-MM-DD'),
+          vlbIdsToExclude: [10],
+          preInterval: { start: '10:35', end: '10:55' },
+          mainInterval: { start: '10:55', end: '11:55' },
+          postInterval: { start: '11:55', end: '12:15' },
+        },
+        // To retrieve available rooms
+        {
+          agencyId: 'WWI',
+          date: tomorrow.format('YYYY-MM-DD'),
+          vlbIdsToExclude: [10],
+          preInterval: { start: '10:35', end: '10:55' },
+          mainInterval: { start: '10:55', end: '11:55' },
+          postInterval: { start: '11:55', end: '12:15' },
+        },
+        // Final check, just before submitting
+        {
+          agencyId: 'WWI',
+          date: tomorrow.format('YYYY-MM-DD'),
+          vlbIdsToExclude: [10],
+          preInterval: { start: '10:35', end: '10:55' },
+          mainInterval: { start: '10:55', end: '11:55' },
+          postInterval: { start: '11:55', end: '12:15' },
+        },
+      ])
+    })
 
     const tomorrowDate = tomorrow.format('YYYY-MM-DD')
     cy.task('getUpdateBookingRequest').then(request =>


### PR DESCRIPTION
The rooms that are occupied by the booking that is being updated shouldn't be removed from the list of available rooms