### PR TITLE
DCS-866: removal of activeCaseloadId. 

### DIFF
--- a/@types/express/index.d.ts
+++ b/@types/express/index.d.ts
@@ -8,7 +8,6 @@ declare module 'express-session' {
     userDetails: {
       name: string
       username: string
-      activeCaseLoadId?: string
     }
   }
 }

--- a/@types/prisonApi/index.d.ts
+++ b/@types/prisonApi/index.d.ts
@@ -6615,10 +6615,6 @@ declare module 'prisonApi' {
        */
       active: boolean
       /**
-       * Current Active Caseload
-       */
-      activeCaseLoadId?: string
-      /**
        * Indicates the user account has expired
        */
       expiredFlag?: boolean

--- a/@types/prisonApi/index.d.ts
+++ b/@types/prisonApi/index.d.ts
@@ -6615,6 +6615,10 @@ declare module 'prisonApi' {
        */
       active: boolean
       /**
+       * Current Active Caseload
+       */
+      activeCaseLoadId?: string
+      /**
        * Indicates the user account has expired
        */
       expiredFlag?: boolean

--- a/backend/routes/amendBooking/changeCommentsController.test.ts
+++ b/backend/routes/amendBooking/changeCommentsController.test.ts
@@ -14,7 +14,7 @@ describe('Change comments controller', () => {
   const req = ({
     originalUrl: 'http://localhost',
     params: { agencyId: 'MDI', offenderNo: 'A12345', bookingId: 123 },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Bob Smith', username: 'BOB_SMITH' } },
+    session: { userDetails: { name: 'Bob Smith', username: 'BOB_SMITH' } },
     body: {},
     flash: jest.fn(),
   } as unknown) as jest.Mocked<Request>

--- a/backend/routes/amendBooking/changeDateAndTimeController.test.ts
+++ b/backend/routes/amendBooking/changeDateAndTimeController.test.ts
@@ -16,7 +16,7 @@ describe('change date and time controller', () => {
   const req = ({
     originalUrl: 'http://localhost',
     params: { agencyId: 'WWI', offenderNo: 'A12345', bookingId: 123 },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Bob Smith', username: 'BOB_SMITH' } },
+    session: { userDetails: { name: 'Bob Smith', username: 'BOB_SMITH' } },
     query: {},
     body: {
       agencyId: 'WWI',

--- a/backend/routes/amendBooking/confirmationController.test.ts
+++ b/backend/routes/amendBooking/confirmationController.test.ts
@@ -12,7 +12,7 @@ describe('video link is available controller', () => {
   const req = ({
     originalUrl: 'http://localhost',
     params: { agencyId: 'MDI', offenderNo: 'A12345', bookingId: 123 },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Bob Smith', username: 'BOB_SMITH' } },
+    session: { userDetails: { name: 'Bob Smith', username: 'BOB_SMITH' } },
     body: {},
     flash: jest.fn(),
   } as unknown) as jest.Mocked<Request>

--- a/backend/routes/amendBooking/selectAvailableRoomsController.test.ts
+++ b/backend/routes/amendBooking/selectAvailableRoomsController.test.ts
@@ -17,7 +17,7 @@ describe('Select available rooms controller', () => {
   const req = ({
     originalUrl: 'http://localhost',
     params: { agencyId: 'MDI', offenderNo: 'A12345', bookingId: '12' },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Bob Smith', username: 'BOB_SMITH' } },
+    session: { userDetails: { name: 'Bob Smith', username: 'BOB_SMITH' } },
     body: {},
     flash: jest.fn(),
   } as unknown) as jest.Mocked<Request>

--- a/backend/routes/amendBooking/videoLinkIsAvailableController.test.ts
+++ b/backend/routes/amendBooking/videoLinkIsAvailableController.test.ts
@@ -13,7 +13,7 @@ describe('video link is available controller', () => {
   const req = ({
     originalUrl: 'http://localhost',
     params: { agencyId: 'MDI', offenderNo: 'A12345', bookingId: 123 },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Bob Smith', username: 'BOB_SMITH' } },
+    session: { userDetails: { name: 'Bob Smith', username: 'BOB_SMITH' } },
     body: {},
     flash: jest.fn(),
   } as unknown) as jest.Mocked<Request>

--- a/backend/routes/amendBooking/videoLinkNotAvailableController.test.ts
+++ b/backend/routes/amendBooking/videoLinkNotAvailableController.test.ts
@@ -8,7 +8,7 @@ describe('video link is not available controller', () => {
   const req = ({
     originalUrl: 'http://localhost',
     params: { agencyId: 'MDI', offenderNo: 'A12345', bookingId: 123 },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Bob Smith', username: 'BOB_SMITH' } },
+    session: { userDetails: { name: 'Bob Smith', username: 'BOB_SMITH' } },
     body: {},
     flash: jest.fn(),
   } as unknown) as jest.Mocked<Request>

--- a/backend/routes/createBooking/confirmationController.js
+++ b/backend/routes/createBooking/confirmationController.js
@@ -9,9 +9,6 @@ const { formatName } = require('../../utils')
 
 module.exports = ({ prisonApi, referenceDataService }) => async (req, res) => {
   const { offenderNo } = req.params
-  const { activeCaseLoadId } = req.session.userDetails
-
-  const locationTypes = await referenceDataService.getRooms(res.locals, activeCaseLoadId)
 
   const appointmentDetails = req.flash('appointmentDetails')
   if (!appointmentDetails || !appointmentDetails.length) throw new Error('Appointment details are missing')
@@ -25,6 +22,7 @@ module.exports = ({ prisonApi, referenceDataService }) => async (req, res) => {
     postAppointment,
     agencyDescription,
     court,
+    agencyId,
   } = appointmentDetails.reduce(
     (acc, current) => ({
       ...acc,
@@ -33,6 +31,7 @@ module.exports = ({ prisonApi, referenceDataService }) => async (req, res) => {
     {}
   )
 
+  const locationTypes = await referenceDataService.getRooms(res.locals, agencyId)
   const { text: locationDescription } = locationTypes.find(loc => loc.value === Number(locationId))
   const { firstName, lastName } = await prisonApi.getPrisonerDetails(res.locals, offenderNo)
 

--- a/backend/routes/createBooking/confirmationController.test.js
+++ b/backend/routes/createBooking/confirmationController.test.js
@@ -20,6 +20,7 @@ describe('Confirm appointments', () => {
     recurring: 'No',
     comment: 'Test',
     court: 'London',
+    agencyId: 'MDI',
   }
 
   beforeEach(() => {
@@ -109,5 +110,15 @@ describe('Confirm appointments', () => {
     req.session.userDetails.authSource = 'auth'
 
     await expect(index(req, res)).rejects.toThrow('Appointment details are missing')
+  })
+  it('Should call referenceDataService with agencyId', async () => {
+    const index = controller({
+      prisonApi,
+      referenceDataService,
+    })
+    res.locals = {}
+    await index(req, res)
+
+    expect(referenceDataService.getRooms).toBeCalledWith({}, 'MDI')
   })
 })

--- a/backend/routes/createBooking/selectCourtController.test.js
+++ b/backend/routes/createBooking/selectCourtController.test.js
@@ -6,7 +6,7 @@ describe('Select court appoinment court', () => {
   const req = {
     originalUrl: 'http://localhost',
     params: { agencyId: 'MDI', offenderNo: 'A12345' },
-    session: { userDetails: { activeCaseLoadId: 'LEI' } },
+    session: { userDetails: {} },
     body: {},
   }
   const res = { locals: {} }

--- a/backend/routes/createBooking/selectRoomsController.test.ts
+++ b/backend/routes/createBooking/selectRoomsController.test.ts
@@ -25,7 +25,7 @@ describe('Select court appointment rooms', () => {
   const req = {
     originalUrl: 'http://localhost',
     params: { agencyId: 'WWI', offenderNo: 'A12345' },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Court User' } },
+    session: { userDetails: { name: 'Court User' } },
     body: {},
     flash: jest.fn(),
   }

--- a/backend/routes/createBooking/startController.test.ts
+++ b/backend/routes/createBooking/startController.test.ts
@@ -80,7 +80,6 @@ describe('Add court appointment', () => {
 
       expect(req.session.userDetails).toEqual({
         ...req.session.userDetails,
-        activeCaseLoadId: 'MDI',
       })
     })
 
@@ -160,6 +159,7 @@ describe('Add court appointment', () => {
         startTimeMinutes: '00',
         endTime: '2021-01-01T02:00:00',
         startTime: '2021-01-01T01:00:00',
+        agencyId: 'MDI',
       })
     })
 

--- a/backend/routes/createBooking/startController.test.ts
+++ b/backend/routes/createBooking/startController.test.ts
@@ -75,14 +75,6 @@ describe('Add court appointment', () => {
       expect(prisonApi.getAgencyDetails).toHaveBeenCalledWith({ context: {} }, 'MDI')
     })
 
-    it('should pack agencyId into user details', async () => {
-      await controller.view()(req, res)
-
-      expect(req.session.userDetails).toEqual({
-        ...req.session.userDetails,
-      })
-    })
-
     it('should render template with default data', async () => {
       await controller.view()(req, res)
 

--- a/backend/routes/createBooking/startController.ts
+++ b/backend/routes/createBooking/startController.ts
@@ -21,10 +21,6 @@ export default class StartController {
       const { firstName, lastName, bookingId } = offenderDetails
       const offenderNameWithNumber = `${formatName(firstName, lastName)} (${offenderNo})`
       const agencyDescription = agencyDetails.description
-      req.session.userDetails = {
-        ...req.session.userDetails,
-        activeCaseLoadId: agencyId,
-      }
 
       return res.render('createBooking/start.njk', {
         offenderNo,
@@ -92,6 +88,7 @@ export default class StartController {
         endTimeMinutes,
         preAppointmentRequired,
         postAppointmentRequired,
+        agencyId,
       })
       return res.redirect(`/${agencyId}/offenders/${offenderNo}/add-court-appointment/select-court`)
     }

--- a/backend/routes/deleteBooking/deleteBookingController.test.ts
+++ b/backend/routes/deleteBooking/deleteBookingController.test.ts
@@ -12,7 +12,7 @@ describe('Delete Booking', () => {
   const req = ({
     originalUrl: 'http://localhost',
     params: { agencyId: 'MDI', offenderNo: 'A12345', bookingId: 123 },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Bob Smith', username: 'BOB_SMITH' } },
+    session: { userDetails: { name: 'Bob Smith', username: 'BOB_SMITH' } },
     body: {},
     flash: jest.fn(),
   } as unknown) as jest.Mocked<Request>

--- a/backend/routes/manageCourts/courtSelectionConfirmationController.test.ts
+++ b/backend/routes/manageCourts/courtSelectionConfirmationController.test.ts
@@ -7,7 +7,7 @@ describe('video link is available controller', () => {
   const req = ({
     originalUrl: 'http://localhost',
     params: { agencyId: 'MDI', offenderNo: 'A12345', bookingId: 123 },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Bob Smith', username: 'BOB_SMITH' } },
+    session: { userDetails: { name: 'Bob Smith', username: 'BOB_SMITH' } },
     body: {},
     flash: jest.fn(),
   } as unknown) as jest.Mocked<Request>

--- a/backend/routes/manageCourts/manageCourtsController.test.ts
+++ b/backend/routes/manageCourts/manageCourtsController.test.ts
@@ -12,7 +12,7 @@ describe('Manage courts controller', () => {
   const req = ({
     originalUrl: 'http://localhost',
     params: { agencyId: 'MDI', offenderNo: 'A12345', bookingId: 123 },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Bob Smith', username: 'BOB_SMITH' } },
+    session: { userDetails: { name: 'Bob Smith', username: 'BOB_SMITH' } },
     body: {},
     flash: jest.fn(),
   } as unknown) as jest.Mocked<Request>

--- a/backend/routes/viewBookings/bookingDetailsController.test.ts
+++ b/backend/routes/viewBookings/bookingDetailsController.test.ts
@@ -12,7 +12,7 @@ describe('Booking details', () => {
   const req = ({
     originalUrl: 'http://localhost',
     params: { agencyId: 'MDI', offenderNo: 'A12345', bookingId: 123 },
-    session: { userDetails: { activeCaseLoadId: 'LEI', name: 'Bob Smith', username: 'BOB_SMITH' } },
+    session: { userDetails: { name: 'Bob Smith', username: 'BOB_SMITH' } },
     body: {},
     flash: jest.fn(),
   } as unknown) as jest.Mocked<Request>

--- a/integration-tests/mockApis/auth.js
+++ b/integration-tests/mockApis/auth.js
@@ -93,7 +93,6 @@ const token = () =>
 
 const stubUser = (username, caseload) => {
   const user = username || 'ITAG_USER'
-  const activeCaseLoadId = caseload || 'MDI'
   return stubFor({
     request: {
       method: 'GET',
@@ -111,7 +110,6 @@ const stubUser = (username, caseload) => {
         active: true,
         name: `${user} name`,
         authSource: 'nomis',
-        activeCaseLoadId,
       },
     },
   })
@@ -130,7 +128,6 @@ const stubUserMe = ({ username = 'ITAG_USER', staffId = 12345, name } = {}) => {
       },
       jsonBody: {
         username,
-        activeCaseLoadId: 'MDI',
         staffId,
         name,
       },

--- a/integration-tests/mockApis/prisonApi.js
+++ b/integration-tests/mockApis/prisonApi.js
@@ -31,7 +31,6 @@ module.exports = {
         jsonBody: {
           firstName: 'JAMES',
           lastName: 'STUART',
-          activeCaseLoadId: 'MDI',
         },
       },
     })


### PR DESCRIPTION
This is not relevant to court users as they don't have a caseload. The application does still however need the prisoner's prison and this is now captured in the agencyId value. agencyId value has now been added to to the flash appointmentDetails so it can be accessed by the confirmationControllers.