### PR TITLE
DCS-874: fixed width of date input error message

### DIFF
--- a/backend/routes/requestBooking/requestBookingValidation.test.ts
+++ b/backend/routes/requestBooking/requestBookingValidation.test.ts
@@ -154,6 +154,18 @@ describe('RequestBookingValidation', () => {
       expect(validator({ ...form, date: 'bob' })).toStrictEqual([errorTypes.date.invalid])
     })
 
+    it('should return an error when an invalid day of month is entered', () => {
+      expect(validator({ ...form, date: '1/02/2020' })).toStrictEqual([errorTypes.date.invalid])
+    })
+
+    it('should return an error when an invalid month is entered', () => {
+      expect(validator({ ...form, date: '31/2/2020' })).toStrictEqual([errorTypes.date.invalid])
+    })
+
+    it('should return an error when an invalid year is entered', () => {
+      expect(validator({ ...form, date: '31/02/20' })).toStrictEqual([errorTypes.date.invalid])
+    })
+
     it('should return an error when no start time is entered', () => {
       expect(validator({ ...form, startTimeHours: '', startTimeMinutes: '' })).toStrictEqual([
         errorTypes.startTime.missing,

--- a/backend/routes/requestBooking/requestBookingValidation.ts
+++ b/backend/routes/requestBooking/requestBookingValidation.ts
@@ -33,7 +33,7 @@ export const errorTypes = {
     missing: { text: 'Select the date of the video link', href: '#date' },
     invalid: {
       text:
-        'Enter the date of the video link using numbers in the format of day, month and year separated using a forward slash',
+        'Enter the date of the video link using numbers in the format of day, month and year separated using a forward slash. For example, 02/08/2020',
       href: '#date',
     },
     past: { text: 'Select a date that is not in the past', href: '#date' },
@@ -80,8 +80,8 @@ const validateDate = (date): ValidationError[] => {
   const errors = []
   const now = moment()
   if (!date) errors.push(errorTypes.date.missing)
-  if (date && !moment(date, DAY_MONTH_YEAR).isValid()) errors.push(errorTypes.date.invalid)
-  if (date && moment(date, DAY_MONTH_YEAR).isBefore(now, 'day')) errors.push(errorTypes.date.past)
+  if (date && !moment(date, DAY_MONTH_YEAR, true).isValid()) errors.push(errorTypes.date.invalid)
+  if (date && moment(date, DAY_MONTH_YEAR, true).isBefore(now, 'day')) errors.push(errorTypes.date.past)
   return errors
 }
 

--- a/sass/application.scss
+++ b/sass/application.scss
@@ -155,3 +155,10 @@ pre {
   white-space: -moz-pre-line; /* Mozilla, since 1999 */
   word-wrap: break-word; /* IE 5.5-7 */
 }
+
+.govuk-\!-width-one-fifth {
+  width: 100% !important;
+  @include govuk-media-query($from: tablet) {
+    width: 20% !important;
+  }
+}

--- a/views/amendBooking/changeDateAndTime.njk
+++ b/views/amendBooking/changeDateAndTime.njk
@@ -33,19 +33,22 @@
                 rows: prisoner | toSummaryViewModel | removePaddingBottom
                 })
             }}
-
             {{
                 govukSummaryList({
                 classes: 'govuk-summary-list--no-border',
                 rows: locations | toSummaryViewModel | removePaddingBottom
                 })
             }}
+        </div>
+    </div>
 
+    <div class="govuk-grid-row govuk-!-padding-left-6">
+        <div class="govuk-grid-column-full">
             <form method="POST" novalidate="novalidate">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
                 <input type="hidden" name="agencyId" value="{{ agencyId }}"/>
 
-                {{ dateTimeAndCourtBriefingPicker(form, errors ) }}
+                {{ dateTimeAndCourtBriefingPicker(form, errors) }}
 
                 {{ govukButton({ 
                     text: "Continue",

--- a/views/components/datePicker/datePicker.njk
+++ b/views/components/datePicker/datePicker.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {%  macro datePicker(params) %}
-    <div class="date-picker-container">
+    <div class="{{params.containerClass | default('')}}">
         {{ govukInput({
             label: {
                 text: params.label,
@@ -11,7 +11,7 @@
             name: params.name,
             errorMessage: params.errorMessage,
             value: params.date,
-            classes: 'date-input ' + params.classes,
+            classes: 'date-input ' + params.classes | default(''),
             autocomplete: 'off',
             attributes: params.attributes
         }) }}

--- a/views/components/dateTimeAndCourtBriefingPicker/dateTimeAndCourtBriefingPicker.njk
+++ b/views/components/dateTimeAndCourtBriefingPicker/dateTimeAndCourtBriefingPicker.njk
@@ -16,7 +16,9 @@
                     name: 'date',
                     date: params.date,
                     errorMessage: errors | findError('date'),
-                    attributes: {'data-disable-past-date':'true', 'data-add-appointment-date': 'true'}
+                    attributes: {'data-disable-past-date':'true', 'data-add-appointment-date': 'true'},
+                    classes: 'govuk-\!-width-one-fifth',
+                    containerClass: 'govuk-\!-width-two-thirds'
                 }) }}
 
 

--- a/views/requestBooking/requestBooking.njk
+++ b/views/requestBooking/requestBooking.njk
@@ -35,7 +35,6 @@
 
                 {{dateTimeAndCourtBriefingPicker(formValues, errors)}}
 
-
                 {{ govukButton({ 
                     text: "Continue",
                     type: "submit"


### PR DESCRIPTION
The error message needed to be up to 2/3rd page width. Have also corrected the error message for the 'request' journey so it is the same as for 'start' and 'amend' journeys. Have ensured the date input field width is consistent across application

**request booking journey**
<img width="900" alt="Screenshot 2021-02-24 at 18 00 46" src="https://user-images.githubusercontent.com/50441412/109044442-50713580-76ca-11eb-80f3-29ebba916c8b.png">

**Create booking journey**

![Screenshot 2021-02-24 at 18 02 28](https://user-images.githubusercontent.com/50441412/109044627-84e4f180-76ca-11eb-87d0-b2cd4582c16a.png)

** amend journey **
![Screenshot 2021-02-24 at 18 03 34](https://user-images.githubusercontent.com/50441412/109044714-a645dd80-76ca-11eb-8aa2-7a9b3b28a6a7.png)

