### PR TITLE
A user can now select the same room for pre, main or post

### DIFF
--- a/backend/routes/amendBooking/selectAvailableRoomsValidation.test.ts
+++ b/backend/routes/amendBooking/selectAvailableRoomsValidation.test.ts
@@ -35,50 +35,6 @@ describe('SelectAvailableRoomsValidation', () => {
     })
   })
 
-  describe('checking for difference of locations', () => {
-    it('should return an error when the pre location and main location are the same', () => {
-      expect(
-        validator({
-          ...form,
-          preLocation: '1',
-          mainLocation: '1',
-        })
-      ).toStrictEqual([errorTypes.preLocation.different])
-    })
-
-    it('should return an error when the post location and main location are the same', () => {
-      expect(
-        validator({
-          ...form,
-          mainLocation: '1',
-          postLocation: '1',
-        })
-      ).toStrictEqual([errorTypes.postLocation.different])
-    })
-
-    it('should not return an error when the pre, main and post locations are all different', () => {
-      expect(
-        validator({
-          ...form,
-          preLocation: '2',
-          mainLocation: '1',
-          postLocation: '3',
-        })
-      ).toStrictEqual([])
-    })
-
-    it('should not return an error when the pre and post locations are the same but different to the main location', () => {
-      expect(
-        validator({
-          ...form,
-          preLocation: '2',
-          mainLocation: '1',
-          postLocation: '2',
-        })
-      ).toStrictEqual([])
-    })
-  })
-
   describe('checking maximum comment length validation', () => {
     it('should return an error when a comment exceeds 3600 characters', () => {
       expect(validator({ ...form, comment: '#'.repeat(3601) })).toStrictEqual([errorTypes.commentLength])

--- a/backend/routes/amendBooking/selectAvailableRoomsValidation.ts
+++ b/backend/routes/amendBooking/selectAvailableRoomsValidation.ts
@@ -11,18 +11,10 @@ export const errorTypes = {
       text: 'Select a prison room for the pre-court hearing briefing',
       href: '#preLocation',
     },
-    different: {
-      text: 'Select a different room for the pre-court hearing to the room for the court hearing briefing',
-      href: '#preLocation',
-    },
   },
   postLocation: {
     missing: {
       text: 'Select a prison room for the post-court hearing briefing',
-      href: '#postLocation',
-    },
-    different: {
-      text: 'Select a different room for the post-court hearing to the room for the court hearing briefing',
       href: '#postLocation',
     },
   },
@@ -50,14 +42,6 @@ export default function validate(form: Record<string, unknown>): ValidationError
   if (!mainLocation) errors.push(errorTypes.missingMainLocation)
   if (postAppointmentRequired === 'true' && !postLocation) errors.push(errorTypes.postLocation.missing)
   if (comment && comment.length > 3600) errors.push(errorTypes.commentLength)
-
-  if (preAppointmentRequired === 'true' && preLocation && mainLocation && preLocation === mainLocation) {
-    errors.push(errorTypes.preLocation.different)
-  }
-
-  if (postAppointmentRequired === 'true' && mainLocation && postLocation && postLocation === mainLocation) {
-    errors.push(errorTypes.postLocation.different)
-  }
 
   return errors
 }

--- a/backend/routes/createBooking/selectRoomsValidation.test.ts
+++ b/backend/routes/createBooking/selectRoomsValidation.test.ts
@@ -35,50 +35,6 @@ describe('SelectAvailableRoomsValidation', () => {
     })
   })
 
-  describe('checking for difference of locations', () => {
-    it('should return an error when the pre location and main location are the same', () => {
-      expect(
-        validator({
-          ...form,
-          preLocation: '1',
-          mainLocation: '1',
-        })
-      ).toStrictEqual([errorTypes.preLocation.different])
-    })
-
-    it('should return an error when the post location and main location are the same', () => {
-      expect(
-        validator({
-          ...form,
-          mainLocation: '1',
-          postLocation: '1',
-        })
-      ).toStrictEqual([errorTypes.postLocation.different])
-    })
-
-    it('should not return an error when the pre, main and post locations are all different', () => {
-      expect(
-        validator({
-          ...form,
-          preLocation: '2',
-          mainLocation: '1',
-          postLocation: '3',
-        })
-      ).toStrictEqual([])
-    })
-
-    it('should not return an error when the pre and post locations are the same but different to the main location', () => {
-      expect(
-        validator({
-          ...form,
-          preLocation: '2',
-          mainLocation: '1',
-          postLocation: '2',
-        })
-      ).toStrictEqual([])
-    })
-  })
-
   describe('checking maximum comment length validation', () => {
     it('should return an error when a comment exceeds 3600 characters', () => {
       expect(validator({ ...form, comment: '#'.repeat(3601) })).toStrictEqual([errorTypes.commentLength])

--- a/backend/routes/createBooking/selectRoomsValidation.ts
+++ b/backend/routes/createBooking/selectRoomsValidation.ts
@@ -11,18 +11,10 @@ export const errorTypes = {
       text: 'Select a prison room for the pre-court hearing briefing',
       href: '#preLocation',
     },
-    different: {
-      text: 'Select a different room for the pre-court hearing to the room for the court hearing briefing',
-      href: '#preLocation',
-    },
   },
   postLocation: {
     missing: {
       text: 'Select a prison room for the post-court hearing briefing',
-      href: '#postLocation',
-    },
-    different: {
-      text: 'Select a different room for the post-court hearing to the room for the court hearing briefing',
       href: '#postLocation',
     },
   },
@@ -50,14 +42,6 @@ export default function validate(form: Record<string, unknown>): ValidationError
   if (!mainLocation) errors.push(errorTypes.missingMainLocation)
   if (postAppointmentRequired === 'true' && !postLocation) errors.push(errorTypes.postLocation.missing)
   if (comment && comment.length > 3600) errors.push(errorTypes.commentLength)
-
-  if (preAppointmentRequired === 'true' && preLocation && mainLocation && preLocation === mainLocation) {
-    errors.push(errorTypes.preLocation.different)
-  }
-
-  if (postAppointmentRequired === 'true' && mainLocation && postLocation && postLocation === mainLocation) {
-    errors.push(errorTypes.postLocation.different)
-  }
 
   return errors
 }

--- a/integration-tests/integration/bookings/amendBooking/amendBooking.spec.js
+++ b/integration-tests/integration/bookings/amendBooking/amendBooking.spec.js
@@ -299,56 +299,6 @@ context('A user can amend a booking', () => {
     changeDateAndTimePage.form.inlineError().contains('Select a date that is not in the past')
   })
 
-  it('A user will be shown a validation message when selecting the same location for pre and main rooms', () => {
-    cy.task('stubLoginCourt', {})
-    cy.task('stubRoomAvailability', {
-      pre: [{ locationId: 100, description: 'Room 1', locationType: 'VIDE' }],
-      main: [
-        { locationId: 100, description: 'Room 1', locationType: 'VIDE' },
-        { locationId: 110, description: 'Room 2', locationType: 'VIDE' },
-      ],
-      post: [{ locationId: 120, description: 'Room 3', locationType: 'VIDE' }],
-    })
-    const tomorrow = moment().add(1, 'days')
-
-    const bookingDetailsPage = BookingDetailsPage.goTo(10, 'John Doe’s')
-    bookingDetailsPage.changeDate().click()
-
-    const changeDateAndTimePage = ChangeDateAndTimePage.verifyOnPage()
-    changeDateAndTimePage.form.date().type(tomorrow.format('DD/MM/YYYY'))
-    changeDateAndTimePage.activeDate().click()
-    changeDateAndTimePage.form.startTimeHours().select('10')
-    changeDateAndTimePage.form.startTimeMinutes().select('55')
-    changeDateAndTimePage.form.endTimeHours().select('11')
-    changeDateAndTimePage.form.endTimeMinutes().select('55')
-    changeDateAndTimePage.form.preAppointmentRequiredYes().click()
-    changeDateAndTimePage.form.postAppointmentRequiredYes().click()
-    changeDateAndTimePage.form.continue().click()
-
-    const videoLinkIsAvailablePage = VideoLinkIsAvailablePage.verifyOnPage()
-    videoLinkIsAvailablePage.continue().click()
-
-    const selectAvailableRoomsPage = SelectAvailableRoomsPage.verifyOnPage()
-
-    const selectAvailableRoomsForm = selectAvailableRoomsPage.form()
-    selectAvailableRoomsForm.preLocation().select('100')
-    selectAvailableRoomsForm.mainLocation().select('100')
-    selectAvailableRoomsForm.postLocation().select('120')
-    selectAvailableRoomsPage.bookVideoLink().click()
-
-    SelectAvailableRoomsPage.verifyOnPage()
-    selectAvailableRoomsForm.preLocation().should('have.value', '100')
-    selectAvailableRoomsForm.mainLocation().should('have.value', '100')
-    selectAvailableRoomsForm.postLocation().should('have.value', '120')
-    selectAvailableRoomsPage.errorSummaryTitle().contains('There is a problem')
-    selectAvailableRoomsPage
-      .errorSummaryBody()
-      .contains('Select a different room for the pre-court hearing to the room for the court hearing briefing')
-    selectAvailableRoomsForm
-      .inlineError()
-      .contains('Select a different room for the pre-court hearing to the room for the court hearing briefing')
-  })
-
   it('Select drop downs for pre and post are not displayed when pre and post appointments are not present', () => {
     const tomorrow = moment().add(1, 'days')
     cy.task('stubLoginCourt', {})


### PR DESCRIPTION
Previously, a user could not select the same room for pre/post and main appointment.
This requirement has now been removed. The control flow was dictated by validation so the relevant bits have been removed.
The change applies to bot the Create and Amend journeys. 