### PR TITLE
DCS-1033 refactoring services referencing court to use same data type

### DIFF
--- a/backend/middleware/checkForPreferredCourts.test.ts
+++ b/backend/middleware/checkForPreferredCourts.test.ts
@@ -1,5 +1,5 @@
 import { mockRequest, mockResponse, mockNext } from '../routes/__test/requestTestUtils'
-import { UserPreferenceCourt } from '../services/manageCourtsService'
+import type { UserPreferenceCourt } from '../services/model'
 
 import checkForPreferredCourts from './checkForPreferredCourts'
 
@@ -7,7 +7,7 @@ describe('Preferred courts check middleware', () => {
   const req = mockRequest({})
   const next = mockNext()
 
-  const createCourt = (courtId: string, courtName: string): UserPreferenceCourt => ({ courtId, courtName })
+  const createCourt = (id: string, name: string): UserPreferenceCourt => ({ id, name })
 
   beforeEach(() => {
     jest.resetAllMocks()

--- a/backend/middleware/currentUser.test.ts
+++ b/backend/middleware/currentUser.test.ts
@@ -17,31 +17,16 @@ describe('Current user', () => {
 
   const courtList = [
     {
-      courtId: 'ABDRCT',
-      courtName: 'Aberdare County Court',
-      type: {
-        courtType: 'COU',
-        courtName: 'Aberdare County Court',
-      },
-      active: true,
+      id: 'ABDRCT',
+      name: 'Aberdare County Court',
     },
     {
-      courtId: 'ABDRMC',
-      courtName: 'Aberdare Mc',
-      type: {
-        courtType: 'MAG',
-        courtName: 'Aberdare Mc',
-      },
-      active: true,
+      id: 'ABDRMC',
+      name: 'Aberdare Mc',
     },
     {
-      courtId: 'ABDRYC',
-      courtName: 'Aberdare Youth Court',
-      type: {
-        courtType: 'YTH',
-        courtName: 'Aberdare Youth Court',
-      },
-      active: true,
+      id: 'ABDRYC',
+      name: 'Aberdare Youth Court',
     },
   ]
 

--- a/backend/routes/amendBooking-v2/changeVideoLinkBookingController.test.ts
+++ b/backend/routes/amendBooking-v2/changeVideoLinkBookingController.test.ts
@@ -69,9 +69,9 @@ describe('change video link booking controller', () => {
     jest.resetAllMocks()
     controller = new ChangeVideoLinkBookingController(bookingService, availabilityCheckService, locationService)
     locationService.getVideoLinkEnabledCourts.mockResolvedValue([
-      { text: 'Westminster Crown Court', value: 'WMRCN' },
-      { text: 'Wimbledon County Court', value: 'WLDCOU' },
-      { text: 'City of London', value: 'CLDN' },
+      { name: 'Westminster Crown Court', id: 'WMRCN' },
+      { name: 'Wimbledon County Court', id: 'WLDCOU' },
+      { name: 'City of London', id: 'CLDN' },
     ])
   })
 

--- a/backend/routes/amendBooking-v2/changeVideoLinkBookingController.ts
+++ b/backend/routes/amendBooking-v2/changeVideoLinkBookingController.ts
@@ -34,7 +34,7 @@ export default class ChangeVideoLinkBookingController {
 
       return res.render('amendBooking-v2/changeVideoLinkBooking.njk', {
         errors,
-        courts,
+        courts: courts.map(c => ({ value: c.id, text: c.name })),
         bookingId,
         agencyId: bookingDetails.agencyId,
         prisoner: {

--- a/backend/routes/createBooking-v2/confirmBooking/confirmBookingController.test.ts
+++ b/backend/routes/createBooking-v2/confirmBooking/confirmBookingController.test.ts
@@ -50,7 +50,7 @@ describe('Select court appointment rooms', () => {
     bookingService.create.mockResolvedValue(123)
     prisonApi.getPrisonerDetails.mockResolvedValue({ firstName: 'BOB', lastName: 'SMITH' } as InmateDetail)
     prisonApi.getAgencyDetails.mockResolvedValue({ description: 'Leeds' } as Agency)
-    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ value: 'LEEMC', text: 'LEEDS' })
+    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ id: 'LEEMC', name: 'LEEDS' })
     locationService.createRoomFinder.mockResolvedValue(
       new RoomFinder([
         { locationId: 1, description: 'Room 1' },
@@ -92,7 +92,7 @@ describe('Select court appointment rooms', () => {
 
       expect(prisonApi.getAgencyDetails).toHaveBeenCalledWith(res.locals, 'WWI')
       expect(prisonApi.getPrisonerDetails).toHaveBeenCalledWith(res.locals, 'A12345')
-      expect(locationService.getVideoLinkEnabledCourt).toHaveBeenCalledWith(res.locals, 'LEEMC', 'USER-1')
+      expect(locationService.getVideoLinkEnabledCourt).toHaveBeenCalledWith(res.locals, 'LEEMC')
       expect(locationService.createRoomFinder).toHaveBeenCalledWith(res.locals, 'WWI')
     })
   })

--- a/backend/routes/createBooking-v2/confirmBooking/confirmBookingController.ts
+++ b/backend/routes/createBooking-v2/confirmBooking/confirmBookingController.ts
@@ -16,14 +16,13 @@ export default class ConfirmBookingController {
 
   public view: RequestHandler = async (req, res) => {
     const { agencyId, offenderNo } = req.params
-    const { username } = res.locals.user
 
     const newBooking = getNewBooking(req)
 
     const [offenderDetails, agencyDetails, court, roomFinder] = await Promise.all([
       this.prisonApi.getPrisonerDetails(res.locals, offenderNo),
       this.prisonApi.getAgencyDetails(res.locals, agencyId),
-      this.locationService.getVideoLinkEnabledCourt(res.locals, newBooking.courtId, username),
+      this.locationService.getVideoLinkEnabledCourt(res.locals, newBooking.courtId),
       this.locationService.createRoomFinder(res.locals, agencyId),
     ])
 
@@ -37,7 +36,7 @@ export default class ConfirmBookingController {
       offender: {
         name: offenderNameWithNumber,
         prison: agencyDetails.description,
-        court: court.text,
+        court: court.name,
       },
       details: {
         date: newBooking.date.format(DATE_ONLY_LONG_FORMAT_SPEC),

--- a/backend/routes/createBooking-v2/newBooking/NewBookingController.test.ts
+++ b/backend/routes/createBooking-v2/newBooking/NewBookingController.test.ts
@@ -60,6 +60,7 @@ describe('Add court appointment', () => {
 
     prisonApi.getPrisonerDetails.mockResolvedValue(prisoner as InmateDetail)
     prisonApi.getAgencyDetails.mockResolvedValue(agencyDetails as Agency)
+    locationService.getVideoLinkEnabledCourts.mockResolvedValue([])
     availabilityCheckService.getAvailability.mockResolvedValue(bookingSlot)
     controller = new NewBookingController(prisonApi, availabilityCheckService, locationService)
   })

--- a/backend/routes/createBooking-v2/newBooking/NewBookingController.ts
+++ b/backend/routes/createBooking-v2/newBooking/NewBookingController.ts
@@ -42,7 +42,7 @@ export default class NewBookingController {
         offenderNameWithNumber,
         agencyDescription,
         bookingId,
-        courts,
+        courts: courts.map(c => ({ value: c.id, text: c.name })),
         errors: req.flash('errors'),
         formValues: req.flash('formValues')[0],
       })

--- a/backend/routes/createBooking-v2/viewConfirmation/confirmationController.test.ts
+++ b/backend/routes/createBooking-v2/viewConfirmation/confirmationController.test.ts
@@ -53,7 +53,7 @@ describe('Confirm appointments', () => {
 
   it('should render page', async () => {
     bookingService.get.mockResolvedValue(bookingDetails)
-    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'City of London' })
+    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'City of London' })
 
     await controller.view(req, res, null)
 
@@ -80,7 +80,7 @@ describe('Confirm appointments', () => {
 
   it('Should call booking service with correct params', async () => {
     bookingService.get.mockResolvedValue(bookingDetails)
-    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'City of London' })
+    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'City of London' })
 
     await controller.view(req, res, null)
 
@@ -89,10 +89,10 @@ describe('Confirm appointments', () => {
 
   it('Should call location service with correct params', async () => {
     bookingService.get.mockResolvedValue(bookingDetails)
-    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'City of London' })
+    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'City of London' })
 
     await controller.view(req, res, null)
 
-    expect(locationService.getVideoLinkEnabledCourt).toBeCalledWith(res.locals, 'CLDN', 'A_USER')
+    expect(locationService.getVideoLinkEnabledCourt).toBeCalledWith(res.locals, 'CLDN')
   })
 })

--- a/backend/routes/createBooking-v2/viewConfirmation/confirmationController.ts
+++ b/backend/routes/createBooking-v2/viewConfirmation/confirmationController.ts
@@ -7,10 +7,9 @@ export default class ConfirmationController {
 
   public view: RequestHandler = async (req, res) => {
     const { videoBookingId } = req.params
-    const { username } = res.locals.user
 
     const details = await this.bookingService.get(res.locals, Number(videoBookingId))
-    const court = await this.locationService.getVideoLinkEnabledCourt(res.locals, details.courtId, username)
+    const court = await this.locationService.getVideoLinkEnabledCourt(res.locals, details.courtId)
 
     res.render('createBooking-v2/confirmation.njk', {
       videolinkPrisonerSearchLink: '/prisoner-search',
@@ -30,7 +29,7 @@ export default class ConfirmationController {
         'post-court hearing briefing': details.postDetails?.description,
       },
       court: {
-        courtLocation: court.text,
+        courtLocation: court.name,
       },
     })
   }

--- a/backend/routes/createBooking/confirmationController.test.ts
+++ b/backend/routes/createBooking/confirmationController.test.ts
@@ -53,7 +53,7 @@ describe('Confirm appointments', () => {
 
   it('should render page', async () => {
     bookingService.get.mockResolvedValue(bookingDetails)
-    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'City of London' })
+    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'City of London' })
 
     await controller.view(req, res, null)
 
@@ -80,7 +80,7 @@ describe('Confirm appointments', () => {
 
   it('Should call booking service with correct params', async () => {
     bookingService.get.mockResolvedValue(bookingDetails)
-    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'City of London' })
+    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'City of London' })
 
     await controller.view(req, res, null)
 
@@ -89,10 +89,10 @@ describe('Confirm appointments', () => {
 
   it('Should call location service with correct params', async () => {
     bookingService.get.mockResolvedValue(bookingDetails)
-    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'City of London' })
+    locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'City of London' })
 
     await controller.view(req, res, null)
 
-    expect(locationService.getVideoLinkEnabledCourt).toBeCalledWith(res.locals, 'CLDN', 'A_USER')
+    expect(locationService.getVideoLinkEnabledCourt).toBeCalledWith(res.locals, 'CLDN')
   })
 })

--- a/backend/routes/createBooking/confirmationController.ts
+++ b/backend/routes/createBooking/confirmationController.ts
@@ -7,12 +7,11 @@ export default class ConfirmationController {
 
   public view: RequestHandler = async (req, res) => {
     const { videoBookingId } = req.params
-    const { username } = res.locals.user
 
     const details = await this.bookingService.get(res.locals, Number(videoBookingId))
-    const court = await this.locationService.getVideoLinkEnabledCourt(res.locals, details.courtId, username)
+    const court = await this.locationService.getVideoLinkEnabledCourt(res.locals, details.courtId)
 
-    res.render('createBooking/confirmation.njk', {
+    return res.render('createBooking/confirmation.njk', {
       videolinkPrisonerSearchLink: '/prisoner-search',
       offender: {
         name: details.prisonerName,
@@ -30,7 +29,7 @@ export default class ConfirmationController {
         'post-court hearing briefing': details.postDetails?.description,
       },
       court: {
-        courtLocation: court.text,
+        courtLocation: court.name,
       },
     })
   }

--- a/backend/routes/createBooking/selectCourtController.test.ts
+++ b/backend/routes/createBooking/selectCourtController.test.ts
@@ -29,9 +29,9 @@ describe('Select court appoinment court', () => {
     prisonApi.getAgencyDetails.mockResolvedValue({ description: 'Moorland' } as Agency)
 
     locationService.getVideoLinkEnabledCourts.mockResolvedValue([
-      { text: 'Westminster Crown Court', value: 'WMRCN' },
-      { text: 'Wimbledon County Court', value: 'WLDCOU' },
-      { text: 'City of London', value: 'CLDN' },
+      { name: 'Westminster Crown Court', id: 'WMRCN' },
+      { name: 'Wimbledon County Court', id: 'WLDCOU' },
+      { name: 'City of London', id: 'CLDN' },
     ])
     req.flash.mockReturnValue([])
 
@@ -57,9 +57,9 @@ describe('Select court appoinment court', () => {
         'createBooking/selectCourt.njk',
         expect.objectContaining({
           courts: [
-            { text: 'Westminster Crown Court', value: 'WMRCN' },
-            { text: 'Wimbledon County Court', value: 'WLDCOU' },
-            { text: 'City of London', value: 'CLDN' },
+            { name: 'Westminster Crown Court', id: 'WMRCN' },
+            { name: 'Wimbledon County Court', id: 'WLDCOU' },
+            { name: 'City of London', id: 'CLDN' },
           ],
           prePostData: {
             'post-court hearing briefing': '14:00 to 14:15',
@@ -97,13 +97,13 @@ describe('Select court appoinment court', () => {
     describe('when no court has been selected', () => {
       it('should return an error', async () => {
         await controller.submit(
-          { ...req, errors: [{ text: 'some error', href: '#courtId' }] } as unknown as Request,
+          { ...req, errors: [{ name: 'some error', href: '#courtId' }] } as unknown as Request,
           res,
           null
         )
 
         expect(res.redirect).toHaveBeenCalledWith('/MDI/offenders/A12345/add-court-appointment/select-court')
-        expect(req.flash).toHaveBeenCalledWith('errors', [{ href: '#courtId', text: 'some error' }])
+        expect(req.flash).toHaveBeenCalledWith('errors', [{ href: '#courtId', name: 'some error' }])
       })
     })
 

--- a/backend/routes/manageCourts/courtSelectionConfirmationController.test.ts
+++ b/backend/routes/manageCourts/courtSelectionConfirmationController.test.ts
@@ -14,31 +14,16 @@ describe('court selection confirmation controller', () => {
 
   const courtList = [
     {
-      courtId: 'ABDRCT',
-      courtName: 'Aberdare County Court',
-      type: {
-        courtType: 'COU',
-        courtName: 'Aberdare County Court',
-      },
-      active: true,
+      id: 'ABDRCT',
+      name: 'Aberdare County Court',
     },
     {
-      courtId: 'ABDRMC',
-      courtName: 'Aberdare Mc',
-      type: {
-        courtType: 'MAG',
-        courtName: 'Aberdare Mc',
-      },
-      active: true,
+      id: 'ABDRMC',
+      name: 'Aberdare Mc',
     },
     {
-      courtId: 'ABDRYC',
-      courtName: 'Aberdare Youth Court',
-      type: {
-        courtType: 'YTH',
-        courtName: 'Aberdare Youth Court',
-      },
-      active: true,
+      id: 'ABDRYC',
+      name: 'Aberdare Youth Court',
     },
   ]
 

--- a/backend/routes/manageCourts/manageCourtsController.test.ts
+++ b/backend/routes/manageCourts/manageCourtsController.test.ts
@@ -1,6 +1,7 @@
 import ManageCourtsController from './manageCourtsController'
-import ManageCourtsService, { UserPreferenceCourt } from '../../services/manageCourtsService'
+import ManageCourtsService from '../../services/manageCourtsService'
 import { mockRequest, mockResponse } from '../__test/requestTestUtils'
+import { UserPreferenceCourt } from '../../services/model'
 
 jest.mock('../../services/manageCourtsService')
 

--- a/backend/routes/requestBooking/selectCourtController.test.ts
+++ b/backend/routes/requestBooking/selectCourtController.test.ts
@@ -24,8 +24,8 @@ describe('Select court controller', () => {
     })
 
     locationService.getVideoLinkEnabledCourts.mockResolvedValue([
-      { value: 'LDNCOU', text: 'London County Court' },
-      { value: 'YKCRN', text: 'York Crown Court' },
+      { id: 'LDNCOU', name: 'London County Court' },
+      { id: 'YKCRN', name: 'York Crown Court' },
     ])
 
     controller = new SelectCourtController(locationService)
@@ -142,7 +142,7 @@ describe('Select court controller', () => {
   describe('Submit', () => {
     it('should stash hearing location into flash and redirect to enter offender details', async () => {
       req.body = { courtId: 'LDNCOU' }
-      locationService.getVideoLinkEnabledCourt.mockResolvedValue({ value: 'LDNCOU', text: 'London County Court' })
+      locationService.getVideoLinkEnabledCourt.mockResolvedValue({ id: 'LDNCOU', name: 'London County Court' })
       mockFlashState({
         errors: [],
         requestBooking: [

--- a/backend/routes/requestBooking/selectCourtController.ts
+++ b/backend/routes/requestBooking/selectCourtController.ts
@@ -71,7 +71,7 @@ export default class SelectCourtController {
           'pre-court hearing briefing': preHearingStartAndEndTime,
           'post-court hearing briefing': postHearingStartAndEndTime,
         },
-        hearingLocations: courtLocations,
+        hearingLocations: courtLocations.map(c => ({ value: c.id, text: c.name })),
         errors,
       })
     }
@@ -80,16 +80,16 @@ export default class SelectCourtController {
   public submit(): RequestHandler {
     return async (req, res) => {
       const { courtId } = req.body
-      const { username } = res.locals.user
+
       if (req.errors) {
         req.flash('errors', req.errors)
         return res.redirect('/request-booking/select-court')
       }
-      const court = await this.locationService.getVideoLinkEnabledCourt(res.locals, courtId, username)
+      const court = await this.locationService.getVideoLinkEnabledCourt(res.locals, courtId)
       const bookingDetails = this.getBookingDetails(req)
       this.packBookingDetails(req, {
         ...bookingDetails,
-        hearingLocation: court.text,
+        hearingLocation: court.name,
       })
       return res.redirect('/request-booking/enter-offender-details')
     }

--- a/backend/routes/viewBookings-v2/viewCourtBookingsController.test.ts
+++ b/backend/routes/viewBookings-v2/viewCourtBookingsController.test.ts
@@ -19,7 +19,7 @@ describe('View court bookings', () => {
     res = mockResponse({ locals: { context: {}, user: { username: 'A_USER' } } })
 
     viewBookingsService.getList.mockResolvedValue({
-      courts: [{ text: 'Westminster Crown Court', value: 'WMRCN' }],
+      courts: [{ name: 'Westminster Crown Court', id: 'WMRCN' }],
       appointments: [{ videoLinkBookingId: 1 }],
     } as Bookings)
   })

--- a/backend/routes/viewBookings-v2/viewCourtBookingsController.ts
+++ b/backend/routes/viewBookings-v2/viewCourtBookingsController.ts
@@ -11,7 +11,7 @@ export = (viewBookingsService: ViewBookingsService): RequestHandler =>
     const { appointments, courts } = await viewBookingsService.getList(res.locals, searchDate, courtId, username)
 
     return res.render('viewBookings/index.njk', {
-      courts: courts.map(court => ({ value: court.value, text: court.text })),
+      courts: courts.map(court => ({ value: court.id, text: court.name })),
       courtId,
       appointments,
       date: searchDate,

--- a/backend/routes/viewBookings/viewCourtBookingsController.test.ts
+++ b/backend/routes/viewBookings/viewCourtBookingsController.test.ts
@@ -19,7 +19,7 @@ describe('View court bookings', () => {
     res = mockResponse({ locals: { context: {}, user: { username: 'A_USER' } } })
 
     viewBookingsService.getList.mockResolvedValue({
-      courts: [{ text: 'Westminster Crown Court', value: 'WMRCN' }],
+      courts: [{ name: 'Westminster Crown Court', id: 'WMRCN' }],
       appointments: [{ videoLinkBookingId: 1 }],
     } as Bookings)
   })

--- a/backend/routes/viewBookings/viewCourtBookingsController.ts
+++ b/backend/routes/viewBookings/viewCourtBookingsController.ts
@@ -11,7 +11,7 @@ export = (viewBookingsService: ViewBookingsService): RequestHandler =>
     const { appointments, courts } = await viewBookingsService.getList(res.locals, searchDate, courtId, username)
 
     return res.render('viewBookings/index.njk', {
-      courts: courts.map(court => ({ value: court.value, text: court.text })),
+      courts: courts.map(court => ({ value: court.id, text: court.name })),
       courtId,
       appointments,
       date: searchDate,

--- a/backend/services/bookingService.test.ts
+++ b/backend/services/bookingService.test.ts
@@ -166,7 +166,7 @@ describe('Booking service', () => {
 
     describe('Creating a booking with all fields', () => {
       it('booking with all fields created', async () => {
-        locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'CLDN' })
+        locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'CLDN' })
 
         const videoBookingId = await service.create(context, 'USER-1', {
           offenderNo: 'AA1234AA',
@@ -206,7 +206,7 @@ describe('Booking service', () => {
       })
 
       it('email sent when all fields provided', async () => {
-        locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'CLDN' })
+        locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'CLDN' })
 
         const videoBookingId = await service.create(context, 'USER-1', {
           offenderNo: 'AA1234AA',
@@ -239,8 +239,8 @@ describe('Booking service', () => {
       describe('Event raising', () => {
         it('should raise event when both pre and post', async () => {
           locationService.getVideoLinkEnabledCourt.mockResolvedValue({
-            text: 'City of London',
-            value: 'CLDN',
+            name: 'City of London',
+            id: 'CLDN',
           })
 
           await service.create(context, 'USER-1', {
@@ -264,8 +264,8 @@ describe('Booking service', () => {
 
         it('should raise event when neither pre and post', async () => {
           locationService.getVideoLinkEnabledCourt.mockResolvedValue({
-            text: 'City of London',
-            value: 'CLDN',
+            name: 'City of London',
+            id: 'CLDN',
           })
 
           await service.create(context, 'USER-1', {
@@ -289,8 +289,8 @@ describe('Booking service', () => {
 
         it('should raise event when only pre and not post', async () => {
           locationService.getVideoLinkEnabledCourt.mockResolvedValue({
-            text: 'City of London',
-            value: 'CLDN',
+            name: 'City of London',
+            id: 'CLDN',
           })
 
           await service.create(context, 'USER-1', {
@@ -316,7 +316,7 @@ describe('Booking service', () => {
 
     describe('Creating a booking with only mandatory fields', () => {
       it('booking with only mandatory fields created', async () => {
-        locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'CLDN' })
+        locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'CLDN' })
 
         await service.create(context, 'USER-1', {
           offenderNo: 'AA1234AA',
@@ -344,7 +344,7 @@ describe('Booking service', () => {
     })
 
     it('email sent when only mandatory fields provided', async () => {
-      locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'CLDN' })
+      locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'CLDN' })
 
       await service.create(context, 'USER-1', {
         offenderNo: 'AA1234AA',
@@ -421,7 +421,7 @@ describe('Booking service', () => {
       prisonApi.getAgencyDetails.mockResolvedValue(agencyDetail)
       prisonApi.getPrisonBooking.mockResolvedValue(offenderDetails)
       whereaboutsApi.getRooms.mockResolvedValue([room(1), room(2), room(3)])
-      locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'CLDN' })
+      locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'CLDN' })
 
       await service.updateComments(context, 'A_USER', 1234, 'another comment')
 
@@ -444,7 +444,7 @@ describe('Booking service', () => {
       prisonApi.getAgencyDetails.mockResolvedValue(agencyDetail)
       prisonApi.getPrisonBooking.mockResolvedValue(offenderDetails)
       whereaboutsApi.getRooms.mockResolvedValue([room(1), room(2), room(3)])
-      locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'CLDN' })
+      locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'CLDN' })
 
       await service.update(context, 'A_USER', 1234, {
         agencyId: 'WWI',
@@ -488,7 +488,7 @@ describe('Booking service', () => {
       prisonApi.getAgencyDetails.mockResolvedValue(agencyDetail)
       prisonApi.getPrisonBooking.mockResolvedValue(offenderDetails)
       whereaboutsApi.getRooms.mockResolvedValue([room(1), room(2), room(3)])
-      locationService.getVideoLinkEnabledCourt.mockResolvedValue({ text: 'City of London', value: 'CLDN' })
+      locationService.getVideoLinkEnabledCourt.mockResolvedValue({ name: 'City of London', id: 'CLDN' })
 
       await service.update(context, 'A_USER', 1234, {
         agencyId: 'WWI',

--- a/backend/services/bookingService.ts
+++ b/backend/services/bookingService.ts
@@ -88,11 +88,11 @@ export = class BookingService {
       ...(postAppointment ? { post: this.toNewAppointment(postAppointment) } : {}),
     })
 
-    const court = await this.locationService.getVideoLinkEnabledCourt(context, courtId, currentUsername)
+    const court = await this.locationService.getVideoLinkEnabledCourt(context, courtId)
 
     await this.notificationService.sendBookingCreationEmails(context, currentUsername, {
       agencyId,
-      court: court.text,
+      court: court.name,
       prison: agencyDetails.description,
       offenderNo,
       prisonerName: formatName(prisonBooking.firstName, prisonBooking.lastName),
@@ -105,7 +105,7 @@ export = class BookingService {
 
     raiseAnalyticsEvent(
       'VLB Appointments',
-      `Video link booked for ${court.text}`,
+      `Video link booked for ${court.name}`,
       `Pre: ${preAppointment ? 'Yes' : 'No'} | Post: ${postAppointment ? 'Yes' : 'No'}`
     )
 

--- a/backend/services/locationService.test.ts
+++ b/backend/services/locationService.test.ts
@@ -85,26 +85,24 @@ describe('Location service', () => {
   describe('Get video link court locations', () => {
     it('Should map video link court locations correctly', async () => {
       const courtLocations = [
-        { courtName: 'London County Court', courtId: 'LDNCOU' },
-        { courtName: 'York Crown Court', courtId: 'YKCRN' },
+        { name: 'London County Court', id: 'LDNCOU' },
+        { name: 'York Crown Court', id: 'YKCRN' },
       ]
       manageCourtsService.getSelectedCourts.mockResolvedValue(courtLocations)
       const response = await service.getVideoLinkEnabledCourts(context, userId)
       expect(response).toEqual([
-        { value: 'LDNCOU', text: 'London County Court' },
-        { value: 'YKCRN', text: 'York Crown Court' },
+        { id: 'LDNCOU', name: 'London County Court' },
+        { id: 'YKCRN', name: 'York Crown Court' },
       ])
     })
+  })
 
+  describe('getVideolinkEnabledCourt', () => {
     it('Should find single matching court from courtId ', async () => {
-      const courtId = 'LDNCOU'
-      const courtLocations = [
-        { courtName: 'London County Court', courtId: 'LDNCOU' },
-        { courtName: 'York Crown Court', courtId: 'YKCRN' },
-      ]
-      manageCourtsService.getSelectedCourts.mockResolvedValue(courtLocations)
-      const response = await service.getVideoLinkEnabledCourt(context, courtId, userId)
-      expect(response).toEqual({ text: 'London County Court', value: 'LDNCOU' })
+      manageCourtsService.getCourt.mockResolvedValue({ name: 'London County Court', id: 'LDNCOU' })
+      const response = await service.getVideoLinkEnabledCourt(context, 'LDNCOU')
+      expect(response).toEqual({ name: 'London County Court', id: 'LDNCOU' })
+      expect(manageCourtsService.getCourt).toBeCalledWith(context, 'LDNCOU')
     })
   })
 })

--- a/backend/services/locationService.ts
+++ b/backend/services/locationService.ts
@@ -1,7 +1,7 @@
-import { Location } from 'whereaboutsApi'
+import { Location, Court } from 'whereaboutsApi'
 import type { PrisonApi } from '../api'
 import type ManageCourtsService from './manageCourtsService'
-import { Context, Prison, Court } from './model'
+import { Context, Prison } from './model'
 import { app } from '../config'
 import { RoomFinder, RoomFinderFactory } from './roomFinder'
 
@@ -39,14 +39,11 @@ export = class LocationService {
 
   public async getVideoLinkEnabledCourts(context: Context, userId: string): Promise<Court[]> {
     const courts = await this.manageCourtsService.getSelectedCourts(context, userId)
-    return courts.map(court => ({
-      value: court.courtId,
-      text: court.courtName,
-    }))
+    return courts
   }
 
-  public async getVideoLinkEnabledCourt(context: Context, courtId: string, userId: string): Promise<Court> {
-    const courts = await this.getVideoLinkEnabledCourts(context, userId)
-    return courts.find(c => c.value === courtId)
+  public async getVideoLinkEnabledCourt(context: Context, courtId: string): Promise<Court> {
+    const court = await this.manageCourtsService.getCourt(context, courtId)
+    return court
   }
 }

--- a/backend/services/manageCourtsService.test.ts
+++ b/backend/services/manageCourtsService.test.ts
@@ -3,7 +3,8 @@ import { Court } from 'whereaboutsApi'
 
 import UserCourtPreferencesApi from '../api/userCourtPreferencesApi'
 import WhereaboutsApi from '../api/whereaboutsApi'
-import ManageCourtsService, { UserPreferenceCourt } from './manageCourtsService'
+import ManageCourtsService from './manageCourtsService'
+import type { UserPreferenceCourt } from './model'
 
 jest.mock('../api/whereaboutsApi')
 jest.mock('../api/userCourtPreferencesApi')
@@ -13,9 +14,9 @@ const userCourtPreferencesApi = new UserCourtPreferencesApi(null) as jest.Mocked
 
 const createCourt = (id: string, name: string): Court => ({ id, name })
 
-const createSeletedCourt = (courtId: string, courtName: string, isSelected?: boolean): UserPreferenceCourt => ({
-  courtId,
-  courtName,
+const createSeletedCourt = (id: string, name: string, isSelected?: boolean): UserPreferenceCourt => ({
+  id,
+  name,
   isSelected,
 })
 

--- a/backend/services/model.ts
+++ b/backend/services/model.ts
@@ -1,4 +1,4 @@
-import { Interval } from 'whereaboutsApi'
+import { Interval, Court } from 'whereaboutsApi'
 import { Moment } from 'moment'
 
 export type Context = unknown
@@ -13,9 +13,8 @@ export type Room = {
   text: string
 }
 
-export type Court = {
-  value: string
-  text: string
+export type UserPreferenceCourt = Court & {
+  isSelected?: boolean
 }
 
 export type AvailabilityRequest = {

--- a/backend/services/viewBookingsService.test.ts
+++ b/backend/services/viewBookingsService.test.ts
@@ -135,8 +135,8 @@ describe('ViewBookingService', () => {
     }
 
     const courts = [
-      { text: 'Westminster Crown Court', value: 'WMRCN' },
-      { text: 'Wimbledon County Court', value: 'WLDCOU' },
+      { name: 'Westminster Crown Court', id: 'WMRCN' },
+      { name: 'Wimbledon County Court', id: 'WLDCOU' },
     ]
 
     beforeEach(() => {

--- a/backend/services/viewBookingsService.ts
+++ b/backend/services/viewBookingsService.ts
@@ -1,13 +1,13 @@
 import type { Prison } from 'prisonApi'
 import type { Prisoner } from 'prisonerOffenderSearchApi'
 import moment from 'moment'
-import type { Appointment, Location, VideoLinkBooking } from 'whereaboutsApi'
+import type { Appointment, Location, VideoLinkBooking, Court } from 'whereaboutsApi'
 
 import PrisonApi from '../api/prisonApi'
 import WhereaboutsApi from '../api/whereaboutsApi'
 import { formatName, getTime, flattenCalls, toMap } from '../utils'
 import { app } from '../config'
-import { Context, HearingType, Bookings, Court } from './model'
+import { Context, HearingType, Bookings } from './model'
 import PrisonerOffenderSearchApi from '../api/prisonerOffenderSearchApi'
 import LocationService from './locationService'
 
@@ -53,7 +53,7 @@ export = class ViewBookingsService {
   }
 
   private sortAlphabetically(courts: Court[]): Court[] {
-    return courts.sort((a, b) => a.text.localeCompare(b.text))
+    return courts.sort((a, b) => a.name.localeCompare(b.name))
   }
 
   public async getList(
@@ -68,7 +68,7 @@ export = class ViewBookingsService {
     ])
 
     const sortedCourts = this.sortAlphabetically(courts)
-    const courtId = courtIdFilter || sortedCourts[0].value
+    const courtId = courtIdFilter || sortedCourts[0].id
 
     const bookingRequests = app.videoLinkEnabledFor.map(prison =>
       this.whereaboutsApi.getVideoLinkBookings(context, prison, searchDate, courtId)

--- a/integration-tests/mockApis/whereabouts.js
+++ b/integration-tests/mockApis/whereabouts.js
@@ -17,20 +17,18 @@ module.exports = {
     })
   },
 
-  stubCourts: (locations = courts, status = 200) => {
+  stubCourts: () => {
     return stubFor({
       request: {
         method: 'GET',
         url: '/whereabouts/court/courts',
       },
       response: {
-        status,
+        status: 200,
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },
-        jsonBody: locations || {
-          courtLocations: ['London', 'Sheffield', 'Leeds'],
-        },
+        jsonBody: courts,
       },
     })
   },

--- a/views/manageCourts/courtSelectionConfirmation.njk
+++ b/views/manageCourts/courtSelectionConfirmation.njk
@@ -17,7 +17,7 @@
             <p class = "govuk-!-margin-top-8">You can now create video link bookings and view existing bookings for the following courts:</p>
             <ul class="govuk-list govuk-list--bullet">
                 {% for item in courts %}
-                    <li data-qa="court">{{item.courtName}}</li>
+                    <li data-qa="court">{{item.name}}</li>
                 {% endfor %}
             </ul>
         </div>

--- a/views/manageCourts/manageCourts.njk
+++ b/views/manageCourts/manageCourts.njk
@@ -57,16 +57,16 @@
                       {% for item in courtList %}
                         <div class="govuk-checkboxes__item">
                           <input  class="govuk-checkboxes__input" 
-                                  id="court-{{item.courtId}}" 
+                                  id="court-{{item.id}}" 
                                   name="courts[]" 
                                   type="checkbox" 
-                                  value="{{item.courtId}}"
+                                  value="{{item.id}}"
                                   {% if item.isSelected %}
                                     checked
                                   {% endif %}
                                   >
-                          <label class="govuk-label govuk-checkboxes__label" for="court-{{item.courtId}}">
-                            {{ item.courtName }}
+                          <label class="govuk-label govuk-checkboxes__label" for="court-{{item.id}}">
+                            {{ item.name }}
                           </label>
                         </div>
                       {% endfor %}


### PR DESCRIPTION
Next step would be to push rendering of selects into templates but will do as a follow up

There was also a method to retrieve court by ID - this worked by retrieving  a filtered list of a users courts.
This was a bit flaky as users could remove courts from their favourite list but potentially still want to see existing court values.

Moved to always retrieve court when querying by id.