### PR TITLE
DCS-1035 Create booking finishing touches

### DIFF
--- a/backend/routes/createBooking/confirmBooking/confirmBookingController.test.ts
+++ b/backend/routes/createBooking/confirmBooking/confirmBookingController.test.ts
@@ -69,6 +69,8 @@ describe('Select court appointment rooms', () => {
       await view(req, res, next)
 
       expect(res.render).toHaveBeenCalledWith('createBooking/confirmBooking.njk', {
+        agencyId: 'WWI',
+        offenderNo: 'A12345',
         details: {
           'Post-court hearing briefing': '14:00 to 14:15',
           'Pre-court hearing briefing': '10:45 to 11:00',

--- a/backend/routes/createBooking/confirmBooking/confirmBookingController.test.ts
+++ b/backend/routes/createBooking/confirmBooking/confirmBookingController.test.ts
@@ -64,9 +64,7 @@ describe('Select court appointment rooms', () => {
 
   describe('view', () => {
     it('should return locations', async () => {
-      const { view } = controller
-
-      await view(req, res, next)
+      await controller.view(req, res, next)
 
       expect(res.render).toHaveBeenCalledWith('createBooking/confirmBooking.njk', {
         agencyId: 'WWI',
@@ -88,9 +86,7 @@ describe('Select court appointment rooms', () => {
     })
 
     it('should call services correctly', async () => {
-      const { view } = controller
-
-      await view(req, res, next)
+      await controller.view(req, res, next)
 
       expect(prisonApi.getAgencyDetails).toHaveBeenCalledWith(res.locals, 'WWI')
       expect(prisonApi.getPrisonerDetails).toHaveBeenCalledWith(res.locals, 'A12345')
@@ -107,8 +103,6 @@ describe('Select court appointment rooms', () => {
     })
 
     it('should redirect back when errors in request', async () => {
-      const { submit } = controller
-
       const reqWithErrors = mockRequest({
         params: { agencyId: 'WWI', offenderNo: 'A12345' },
         body: {
@@ -117,45 +111,39 @@ describe('Select court appointment rooms', () => {
         errors: [{ href: '#preLocation' }],
       })
 
-      await submit(reqWithErrors, res, next)
+      await controller.submit(reqWithErrors, res, next)
 
       expect(res.redirect).toHaveBeenCalledWith('/WWI/offenders/A12345/add-court-appointment/select-rooms')
       expect(bookingService.create).not.toHaveBeenCalled()
     })
 
     it('should redirect to confirmation page', async () => {
-      const { submit } = controller
-
       req.body = {
         comment: 'Test',
       }
 
-      await submit(req, res, next)
+      await controller.submit(req, res, next)
 
       expect(res.redirect).toHaveBeenCalledWith('/offenders/A12345/confirm-appointment/123')
     })
 
-    it('should redirect to confirmation page if no pre or post rooms are required', async () => {
-      const { submit } = controller
+    it('should redirect to room no longer available page', async () => {
+      bookingService.create.mockResolvedValue(false)
 
-      req.body = {
-        comment: 'Test',
-      }
+      await controller.submit(req, res, next)
 
-      await submit(req, res, next)
-
-      expect(res.redirect).toHaveBeenCalledWith('/offenders/A12345/confirm-appointment/123')
+      expect(res.redirect).toHaveBeenCalledWith(
+        '/WWI/offenders/A12345/add-court-appointment/video-link-no-longer-available'
+      )
     })
 
     describe('should call the booking service with correct details', () => {
       it('with all fields ', async () => {
-        const { submit } = controller
-
         req.body = {
           comment: 'Test',
         }
 
-        await submit(req, res, next)
+        await controller.submit(req, res, next)
 
         expect(bookingService.create).toBeCalledWith(res.locals, 'COURT_USER', {
           agencyId: 'WWI',
@@ -173,6 +161,22 @@ describe('Select court appointment rooms', () => {
       it('with only mandatory fields ', async () => {
         const { submit } = controller
 
+        req = mockRequest({
+          params: { agencyId: 'WWI', offenderNo: 'A12345' },
+          signedCookies: {
+            'booking-creation': {
+              courtId: 'LEEMC',
+              bookingId: '123456',
+              date: '2017-11-10T00:00:00',
+              postRequired: 'false',
+              preRequired: 'false',
+              endTime: '2017-11-10T14:00:00',
+              startTime: '2017-11-10T11:00:00',
+              mainLocation: '2',
+            },
+          },
+        })
+
         await submit(req, res, next)
 
         expect(bookingService.create).toBeCalledWith(res.locals, 'COURT_USER', {
@@ -182,9 +186,9 @@ describe('Select court appointment rooms', () => {
           mainEndTime: moment('2017-11-10T14:00:00', DATE_TIME_FORMAT_SPEC, true),
           mainStartTime: moment('2017-11-10T11:00:00', DATE_TIME_FORMAT_SPEC, true),
           offenderNo: 'A12345',
-          pre: 1,
+          pre: undefined,
           main: 2,
-          post: 3,
+          post: undefined,
         })
       })
     })

--- a/backend/routes/createBooking/confirmBooking/confirmBookingController.ts
+++ b/backend/routes/createBooking/confirmBooking/confirmBookingController.ts
@@ -69,7 +69,7 @@ export default class ConfirmBookingController {
 
     const { username } = req.session.userDetails
 
-    const videoBookingId = await this.bookingService.create(res.locals, username, {
+    const success = await this.bookingService.create(res.locals, username, {
       offenderNo,
       agencyId,
       courtId: newBooking.courtId,
@@ -81,8 +81,13 @@ export default class ConfirmBookingController {
       comment: form.comment,
     })
 
+    if (success === false) {
+      return res.redirect(`/${agencyId}/offenders/${offenderNo}/add-court-appointment/video-link-no-longer-available`)
+    }
+
     clearNewBooking(res)
 
+    const videoBookingId = success
     return res.redirect(`/offenders/${offenderNo}/confirm-appointment/${videoBookingId}`)
   }
 }

--- a/backend/routes/createBooking/confirmBooking/confirmBookingController.ts
+++ b/backend/routes/createBooking/confirmBooking/confirmBookingController.ts
@@ -33,6 +33,8 @@ export default class ConfirmBookingController {
     const form = input || {}
 
     return res.render('createBooking/confirmBooking.njk', {
+      agencyId,
+      offenderNo,
       offender: {
         name: offenderNameWithNumber,
         prison: agencyDetails.description,

--- a/backend/routes/createBooking/index.ts
+++ b/backend/routes/createBooking/index.ts
@@ -11,6 +11,7 @@ import asyncMiddleware from '../../middleware/asyncMiddleware'
 
 import { Services } from '../../services'
 import { ensureNewBookingPresentMiddleware } from './state'
+import RoomNoLongerAvailableController from './roomNoLongerAvailable/RoomNoLongerAvailableController'
 
 export default function createRoutes(services: Services): Router {
   const router = express.Router({ mergeParams: true })
@@ -57,12 +58,22 @@ export default function createRoutes(services: Services): Router {
     router.post(path, checkNewBookingPresent, confirmBookingValidation, asyncMiddleware(submit))
   }
 
-  const { view } = new ConfirmationController(services.bookingService, services.locationService)
-  router.get(
-    '/offenders/:offenderNo/confirm-appointment/:videoBookingId',
-    withRetryLink('/prisoner-search'),
-    asyncMiddleware(view)
-  )
+  {
+    const { view } = new ConfirmationController(services.bookingService, services.locationService)
+    router.get(
+      '/offenders/:offenderNo/confirm-appointment/:videoBookingId',
+      withRetryLink('/prisoner-search'),
+      asyncMiddleware(view)
+    )
+  }
+
+  {
+    const { view } = new RoomNoLongerAvailableController()
+    router.get(
+      '/:agencyId/offenders/:offenderNo/add-court-appointment/video-link-no-longer-available',
+      asyncMiddleware(view)
+    )
+  }
 
   return router
 }

--- a/backend/routes/createBooking/newBooking/NewBookingController.ts
+++ b/backend/routes/createBooking/newBooking/NewBookingController.ts
@@ -2,8 +2,8 @@ import { RequestHandler, Request, Response } from 'express'
 import { formatName } from '../../../utils'
 import type PrisonApi from '../../../api/prisonApi'
 import type { LocationService, AvailabilityCheckServiceV2 } from '../../../services'
-import { NewBooking } from './form'
-import { clearNewBooking, setNewBooking } from '../state'
+import { NewBooking, toFormValues } from './form'
+import { clearNewBooking, getNewBooking, setNewBooking } from '../state'
 
 export default class NewBookingController {
   public constructor(
@@ -35,6 +35,8 @@ export default class NewBookingController {
       const offenderNameWithNumber = `${formatName(firstName, lastName)} (${offenderNo})`
       const agencyDescription = agencyDetails.description
 
+      const newBooking = getNewBooking(req)
+
       return res.render('createBooking/newBooking.njk', {
         rooms,
         offenderNo,
@@ -43,7 +45,7 @@ export default class NewBookingController {
         bookingId,
         courts,
         errors: req.flash('errors'),
-        formValues: req.flash('formValues')[0],
+        formValues: req.flash('formValues')[0] || (newBooking && toFormValues(newBooking)),
       })
     }
   }

--- a/backend/routes/createBooking/newBooking/NewBookingController.ts
+++ b/backend/routes/createBooking/newBooking/NewBookingController.ts
@@ -41,7 +41,7 @@ export default class NewBookingController {
         offenderNameWithNumber,
         agencyDescription,
         bookingId,
-        courts: courts.map(c => ({ value: c.id, text: c.name })),
+        courts,
         errors: req.flash('errors'),
         formValues: req.flash('formValues')[0],
       })

--- a/backend/routes/createBooking/newBooking/form.test.ts
+++ b/backend/routes/createBooking/newBooking/form.test.ts
@@ -1,6 +1,6 @@
 import moment from 'moment'
 import { buildDate, DATE_TIME_FORMAT_SPEC, DAY_MONTH_YEAR } from '../../../shared/dateHelpers'
-import { NewBooking, SelectAlternative } from './form'
+import { NewBooking, SelectAlternative, toFormValues } from './form'
 
 describe('NewBooking', () => {
   test('check parse required fields', () => {
@@ -92,6 +92,40 @@ describe('NewBooking', () => {
         postRequired: 'false',
       })
     ).toThrowError('Missing or invalid keys: startTimeHours,endTimeHours')
+  })
+})
+
+describe('toFormValues', () => {
+  test('all values', () => {
+    expect(
+      toFormValues(
+        NewBooking({
+          bookingId: '123456',
+          courtId: 'COURT-1',
+          date: '22/01/2020',
+          startTimeHours: '10',
+          startTimeMinutes: '30',
+          endTimeHours: '11',
+          endTimeMinutes: '00',
+          mainLocation: '12',
+          preRequired: 'false',
+          postRequired: 'false',
+        })
+      )
+    ).toStrictEqual({
+      bookingId: '123456',
+      courtId: 'COURT-1',
+      date: '22/01/2020',
+      endTimeHours: '11',
+      endTimeMinutes: '00',
+      mainLocation: '12',
+      postLocation: undefined,
+      postRequired: 'false',
+      preLocation: undefined,
+      preRequired: 'false',
+      startTimeHours: '10',
+      startTimeMinutes: '30',
+    })
   })
 })
 

--- a/backend/routes/createBooking/newBooking/form.ts
+++ b/backend/routes/createBooking/newBooking/form.ts
@@ -1,5 +1,5 @@
 import moment, { Moment } from 'moment'
-import { buildDate, DATE_TIME_FORMAT_SPEC, DAY_MONTH_YEAR } from '../../../shared/dateHelpers'
+import { buildDate, DATE_TIME_FORMAT_SPEC, DAY_MONTH_YEAR, HOURS_TIME, MINUTES_TIME } from '../../../shared/dateHelpers'
 import { assertHasStringValues, assertHasOptionalStringValues } from '../../../utils'
 
 export type NewBooking = {
@@ -45,6 +45,21 @@ export function NewBooking(form: unknown): NewBooking {
     postLocation: postRequired ? parseInt(form.postLocation, 10) : null,
   }
 }
+
+export const toFormValues = (booking: NewBooking): Record<string, string> => ({
+  courtId: booking.courtId,
+  bookingId: booking.bookingId.toString(),
+  date: booking.date.format(DAY_MONTH_YEAR),
+  startTimeHours: booking.startTime.format(HOURS_TIME),
+  startTimeMinutes: booking.startTime.format(MINUTES_TIME),
+  endTimeHours: booking.endTime.format(HOURS_TIME),
+  endTimeMinutes: booking.endTime.format(MINUTES_TIME),
+  preRequired: booking.preRequired?.toString(),
+  postRequired: booking.postRequired?.toString(),
+  preLocation: booking.preRequired ? booking.preLocation?.toString() : undefined,
+  mainLocation: booking.mainLocation.toString(),
+  postLocation: booking.postRequired ? booking.postLocation?.toString() : undefined,
+})
 
 export type SelectAlternative = {
   startTime: Moment

--- a/backend/routes/createBooking/newBooking/selectRoomValidation.test.ts
+++ b/backend/routes/createBooking/newBooking/selectRoomValidation.test.ts
@@ -30,7 +30,7 @@ describe('SelectAvailableRoomsValidation', () => {
           mainLocation: '',
           postLocation: '',
         })
-      ).toStrictEqual([errorTypes.preLocation.missing, errorTypes.missingMainLocation, errorTypes.postLocation.missing])
+      ).toStrictEqual([errorTypes.missingMainLocation, errorTypes.preLocation.missing, errorTypes.postLocation.missing])
     })
   })
 })

--- a/backend/routes/createBooking/newBooking/selectRoomValidation.ts
+++ b/backend/routes/createBooking/newBooking/selectRoomValidation.ts
@@ -27,8 +27,8 @@ export default function validate(form: Record<string, unknown>): ValidationError
 
   const errors: ValidationError[] = []
 
-  if (preRequired === 'true' && !preLocation) errors.push(errorTypes.preLocation.missing)
   if (!mainLocation) errors.push(errorTypes.missingMainLocation)
+  if (preRequired === 'true' && !preLocation) errors.push(errorTypes.preLocation.missing)
   if (postRequired === 'true' && !postLocation) errors.push(errorTypes.postLocation.missing)
 
   return errors

--- a/backend/routes/createBooking/roomNoLongerAvailable/RoomNoLongerAvailableController.test.ts
+++ b/backend/routes/createBooking/roomNoLongerAvailable/RoomNoLongerAvailableController.test.ts
@@ -1,0 +1,30 @@
+import RoomNoLongerAvailableController from './RoomNoLongerAvailableController'
+
+import { mockRequest, mockResponse } from '../../__test/requestTestUtils'
+
+describe('Not available page', () => {
+  const res = mockResponse({})
+
+  let controller: RoomNoLongerAvailableController
+
+  beforeEach(() => {
+    controller = new RoomNoLongerAvailableController()
+  })
+
+  describe('view', () => {
+    it('should render template with data', async () => {
+      const req = mockRequest({
+        params: {
+          offenderNo: 'A12345',
+          agencyId: 'MDI',
+        },
+      })
+
+      await controller.view(req, res, null)
+
+      expect(res.render).toHaveBeenCalledWith('createBooking/roomNoLongerAvailable.njk', {
+        continueLink: '/MDI/offenders/A12345/add-court-appointment',
+      })
+    })
+  })
+})

--- a/backend/routes/createBooking/roomNoLongerAvailable/RoomNoLongerAvailableController.ts
+++ b/backend/routes/createBooking/roomNoLongerAvailable/RoomNoLongerAvailableController.ts
@@ -1,0 +1,10 @@
+import type { RequestHandler } from 'express'
+
+export default class RoomNoLongerAvailableController {
+  public view: RequestHandler = async (req, res) => {
+    const { offenderNo, agencyId } = req.params
+    res.render('createBooking/roomNoLongerAvailable.njk', {
+      continueLink: `/${agencyId}/offenders/${offenderNo}/add-court-appointment`,
+    })
+  }
+}

--- a/backend/shared/dateAndTimeValidation.test.ts
+++ b/backend/shared/dateAndTimeValidation.test.ts
@@ -191,11 +191,11 @@ describe('DateAndTimeValidation', () => {
           postRequired: '',
         })
       ).toStrictEqual([
-        errorTypes.missingPreCourt,
-        errorTypes.missingPostCourt,
         errorTypes.date.missing,
         errorTypes.startTime.missing,
         errorTypes.endTime.missing,
+        errorTypes.missingPreCourt,
+        errorTypes.missingPostCourt,
       ])
     })
   })

--- a/backend/shared/dateAndTimeValidation.ts
+++ b/backend/shared/dateAndTimeValidation.ts
@@ -85,11 +85,11 @@ export default function validate(form: Record<string, unknown>): ValidationError
 
   const errors: ValidationError[] = []
 
-  if (!preRequired) errors.push(errorTypes.missingPreCourt)
-  if (!postRequired) errors.push(errorTypes.missingPostCourt)
-
   errors.push(...validateDate(date))
   errors.push(...validateTime(date, startTimeHours, startTimeMinutes, endTimeHours, endTimeMinutes))
+
+  if (!preRequired) errors.push(errorTypes.missingPreCourt)
+  if (!postRequired) errors.push(errorTypes.missingPostCourt)
 
   return errors
 }

--- a/backend/utils/nunjucksSetup.js
+++ b/backend/utils/nunjucksSetup.js
@@ -170,7 +170,8 @@ module.exports = (app, path) => {
     const items = array.map(item => ({
       value: item[valueKey],
       text: item[textKey],
-      selected: item[valueKey] === parseInt(value, 10),
+      // eslint-disable-next-line eqeqeq
+      selected: item[valueKey] == value,
     }))
     return [emptyOption, ...items]
   })

--- a/integration-tests/integration/bookings/createBooking.spec.js
+++ b/integration-tests/integration/bookings/createBooking.spec.js
@@ -524,6 +524,114 @@ context('A user can add a video link', () => {
     confirmationPage.courtLocation().contains('Aberdare County Court')
   })
 
+  it('A user with decides to change their appointment', () => {
+    const offenderNo = 'A12345'
+    cy.task('stubLoginCourt', { preferredCourts: ['ABDRCT', 'BANBCT'] })
+    cy.login()
+    cy.task('stubGetRooms', { agencyId: 'MDI', rooms: allRooms })
+    cy.visit(`/MDI/offenders/${offenderNo}/new-court-appointment`)
+    cy.task('stubAvailabilityCheck', { matched: true })
+
+    {
+      const newBookingPage = NewBookingPage.verifyOnPage()
+      const newBookingForm = newBookingPage.form()
+      newBookingForm.date().type(moment().add(1, 'days').format('DD/MM/YYYY'))
+
+      newBookingForm.court().select('ABDRCT')
+      newBookingPage.activeDate().click()
+      newBookingForm.startTimeHours().select('11')
+      newBookingForm.startTimeMinutes().select('00')
+      newBookingForm.endTimeHours().select('11')
+      newBookingForm.endTimeMinutes().select('30')
+      newBookingForm.preAppointmentRequiredYes().click()
+      newBookingForm.postAppointmentRequiredYes().click()
+      newBookingForm.selectPreAppointmentLocation().select('1')
+      newBookingForm.selectMainAppointmentLocation().select('2')
+      newBookingForm.selectPostAppointmentLocation().select('3')
+      newBookingForm.submitButton().click()
+    }
+
+    {
+      const confirmBookingPage = ConfirmBookingPage.verifyOnPage()
+      confirmBookingPage.changeBooking().click()
+    }
+
+    {
+      const newBookingPage = NewBookingPage.verifyOnPage()
+      const newBookingForm = newBookingPage.form()
+      newBookingForm.date().should('have.value', moment().add(1, 'days').format('DD/MM/YYYY'))
+      newBookingForm.court().should('have.value', 'ABDRCT')
+      newBookingForm.startTimeHours().contains('11')
+      newBookingForm.startTimeMinutes().contains('00')
+      newBookingForm.endTimeHours().contains('11')
+      newBookingForm.endTimeMinutes().contains('30')
+      newBookingForm.selectPreAppointmentLocation().should('have.value', '1')
+      newBookingForm.selectMainAppointmentLocation().should('have.value', '2')
+      newBookingForm.selectPostAppointmentLocation().should('have.value', '3')
+
+      newBookingForm.endTimeMinutes().select('45')
+      newBookingForm.postAppointmentRequiredNo().click()
+
+      newBookingForm.submitButton().click()
+    }
+
+    {
+      const confirmBookingPage = ConfirmBookingPage.verifyOnPage()
+      confirmBookingPage.endTime().contains('11:45')
+      confirmBookingPage.preTime().should('exist')
+      confirmBookingPage.postTime().should('not.exist')
+
+      cy.task('stubGetVideoLinkBooking', {
+        agencyId: 'MDI',
+        bookingId: 1,
+        comment: 'A comment',
+        courtId: 'ABDRCT',
+        videoLinkBookingId: 123,
+        pre: {
+          locationId: 1,
+          startTime: moment().add(1, 'days').set({ hour: 10, minute: 45 }),
+          endTime: moment().add(1, 'days').set({ hour: 11, minute: 0 }),
+        },
+        main: {
+          locationId: 2,
+          startTime: moment().add(1, 'days').set({ hour: 11, minute: 0 }),
+          endTime: moment().add(1, 'days').set({ hour: 11, minute: 45 }),
+        },
+      })
+
+      confirmBookingPage.form().submitButton().click()
+    }
+
+    const confirmationPage = ConfirmationPage.verifyOnPage()
+    confirmationPage.offenderName().contains('John Doe')
+    confirmationPage.prison().contains('Moorland')
+    confirmationPage.room().contains('Room 2')
+    confirmationPage.startTime().contains('11:00')
+    confirmationPage.endTime().contains('11:45')
+    confirmationPage.date().contains(moment().add(1, 'days').format('D MMMM YYYY'))
+    confirmationPage.legalBriefingBefore().contains('10:45 to 11:00')
+    confirmationPage.legalBriefingAfter().should('not.exist')
+    confirmationPage.courtLocation().contains('Aberdare County Court')
+
+    cy.task('getBookingRequest').then(request => {
+      expect(request).to.deep.equal({
+        bookingId: 14,
+        courtId: 'ABDRCT',
+        madeByTheCourt: true,
+        pre: {
+          locationId: 1,
+          startTime: moment().add(1, 'days').format(`YYYY-MM-DD[T10:45:00]`),
+          endTime: moment().add(1, 'days').format(`YYYY-MM-DD[T11:00:00]`),
+        },
+        main: {
+          locationId: 2,
+          startTime: moment().add(1, 'days').format(`YYYY-MM-DD[T11:00:00]`),
+          endTime: moment().add(1, 'days').format(`YYYY-MM-DD[T11:45:00]`),
+        },
+      })
+    })
+  })
+
   // TODO Re-add once availability check
   xit('User selects rooms but they become unavailable before confirmation', () => {
     // This is a bit of a cheat, as we only check the user role.

--- a/integration-tests/integration/bookings/createBooking.spec.js
+++ b/integration-tests/integration/bookings/createBooking.spec.js
@@ -487,7 +487,7 @@ context('A user can add a video link', () => {
     confirmBookingPage.date().contains(moment().add(1, 'days').format('D MMMM YYYY'))
     confirmBookingPage.preTime().contains('11:45 to 12:00')
     confirmBookingPage.postTime().contains('12:30 to 12:45')
-
+    cy.task('stubAvailabilityCheck', { matched: true, alternatives: [] })
     cy.task('stubGetVideoLinkBooking', {
       agencyId: 'MDI',
       bookingId: 1,
@@ -632,13 +632,13 @@ context('A user can add a video link', () => {
     })
   })
 
-  // TODO Re-add once availability check
-  xit('User selects rooms but they become unavailable before confirmation', () => {
+  it('User selects rooms but they become unavailable before confirmation', () => {
     // This is a bit of a cheat, as we only check the user role.
     // Saves dealing with logging out and logging back in in the setup.
     const offenderNo = 'A12345'
     cy.task('stubLoginCourt', {})
     cy.task('stubGetRooms', { agencyId: 'MDI', rooms: allRooms })
+    cy.task('stubAvailabilityCheck', { matched: true, alternatives: [] })
     cy.login()
     cy.visit(`/MDI/offenders/${offenderNo}/new-court-appointment`)
 
@@ -659,9 +659,23 @@ context('A user can add a video link', () => {
     newBookingForm.submitButton().click()
 
     const confirmBookingPage = ConfirmBookingPage.verifyOnPage()
+    cy.task('stubAvailabilityCheck', { matched: false, alternatives: [] })
     confirmBookingPage.form().submitButton().click()
 
     const noLongerAvailablePage = NoLongerAvailablePage.verifyOnPage()
     noLongerAvailablePage.continue().click()
+
+    {
+      const newBookingPage = NewBookingPage.verifyOnPage()
+      const newBookingForm = newBookingPage.form()
+      newBookingForm.date().should('have.value', moment().add(1, 'days').format('DD/MM/YYYY'))
+      newBookingForm.startTimeHours().contains('11')
+      newBookingForm.startTimeMinutes().contains('00')
+      newBookingForm.endTimeHours().contains('11')
+      newBookingForm.endTimeMinutes().contains('30')
+      newBookingForm.selectPreAppointmentLocation().should('have.value', '1')
+      newBookingForm.selectMainAppointmentLocation().should('have.value', '2')
+      newBookingForm.selectPostAppointmentLocation().should('have.value', '3')
+    }
   })
 })

--- a/integration-tests/pages/createBooking/confirmBookingPage.js
+++ b/integration-tests/pages/createBooking/confirmBookingPage.js
@@ -16,6 +16,7 @@ const confirmBookingPage = () =>
     mainRoom: () => cy.get('.qa-prisonRoomForCourtHearing-value'),
     preRoom: () => cy.get('.qa-PrisonRoomForPreCourtHearingBriefing-value'),
     postRoom: () => cy.get('.qa-PrisonRoomForPostCourtHearingBriefing-value'),
+    changeBooking: () => cy.get('[data-qa="change-booking"]'),
   })
 
 export default {

--- a/views/createBooking/confirmBooking.njk
+++ b/views/createBooking/confirmBooking.njk
@@ -65,6 +65,10 @@
                             type: 'submit',
                             classes: "govuk-!-margin-right-2"
                     }) }}
+
+                    <p class="govuk-body govuk-!-margin-top-1">
+                        <a href='/{{agencyId}}/offenders/{{offenderNo}}/add-court-appointment' class="govuk-link govuk-link--no-visited-state" data-qa="change-booking">Change booking</a>
+                    </p>
                 </form>
             </div>
         </div>

--- a/views/createBooking/newBooking.njk
+++ b/views/createBooking/newBooking.njk
@@ -67,7 +67,7 @@
                 <input type="hidden" name="bookingId" value="{{ bookingId }}">
 
                 {% if courts.length === 1 %}
-                    <input type="hidden" name="courtId" value="{{ courts | first | showValue }}" />
+                    <input type="hidden" name="courtId" value="{{ courts[0].id }}" />
                     {{ govukSummaryList({
                         classes: "govuk-summary-list--no-border",
                         rows: [{
@@ -76,7 +76,7 @@
                                 classes: "govuk-summary-list__key qa-court-key govuk-!-padding-bottom-0 govuk-!-width-one-half"
                                 },
                             value: {
-                                text: courts | first | showText,
+                                text: courts[0].name,
                                 classes: "govuk-summary-list__value qa-court-value govuk-!-padding-bottom-0 govuk-!-width-one-half"
                                 }
                             }]
@@ -89,7 +89,7 @@
                         label: {
                             text: "Which court is the hearing for?"
                         },
-                        items: courts | addDefaultSelectedVale('Select'),
+                        items: courts | toSelect('id', 'name', formValues.courtId),
                         errorMessage: errors | findError("courtId")
                     }) }}
                 {% endif %}    


### PR DESCRIPTION
This covers four individual changes: 

**Adding missing change booking link in the create flow**

The link on the create booking confirm booking page was missing:  
<kbd>
<img width="1035" alt="Screenshot 2021-07-12 at 09 13 09" src="https://user-images.githubusercontent.com/1517745/125253507-65eda180-e2f1-11eb-877f-f71bad7d4e16.png">
</kbd>

**Ensure court is populated after validation failure**

Previously the court on the create booking flow would clear out if the form was submitted with errors: 
<kbd>
<img width="673" alt="Screenshot 2021-07-12 at 09 14 29" src="https://user-images.githubusercontent.com/1517745/125253679-946b7c80-e2f1-11eb-8713-66ad4b244c7e.png">
</kbd>


**Populate new booking form from cookie, if it is present.**

if you clicked a link that goes back to the search for new booking page, it should populate the form from the cookie content so the user can easily make adjustments to their previous criteria:
<kbd>
<img width="488" alt="Screenshot 2021-07-12 at 09 17 32" src="https://user-images.githubusercontent.com/1517745/125254077-06dc5c80-e2f2-11eb-9646-2b68369691c4.png">
</kbd>
<kbd>
<img width="247" alt="Screenshot 2021-07-12 at 09 16 17" src="https://user-images.githubusercontent.com/1517745/125254083-080d8980-e2f2-11eb-8a42-54460b6b4faa.png">
</kbd>
<kbd>
<img width="720" alt="Screenshot 2021-07-12 at 09 16 09" src="https://user-images.githubusercontent.com/1517745/125254085-080d8980-e2f2-11eb-94cc-81ac55ab1b0b.png">
</kbd>


**Adding final availability check back in**

After a user  confirms their booking and possibly enters a comment, we should do a final availability check. If this fails it should go to the room no longer available page:

<kbd>
<img width="658" alt="Screenshot 2021-07-12 at 09 20 37" src="https://user-images.githubusercontent.com/1517745/125254522-72bec500-e2f2-11eb-9213-414e1eb1f2e4.png">

</kbd>
