### PR TITLE
DCS-1090 Fixing a couple bugs

### DIFF
--- a/backend/routes/amendBooking/videoLinkNotAvailableController.test.ts
+++ b/backend/routes/amendBooking/videoLinkNotAvailableController.test.ts
@@ -67,6 +67,37 @@ describe('video link is not available controller', () => {
       expect(res.redirect).toHaveBeenCalledWith('/booking-details/123')
     })
 
+    it('should redirect back to booking search page if have since selected an available option', async () => {
+      const req = mockRequest({
+        params: { bookingId: '123' },
+        body: {},
+        signedCookies: {
+          'booking-update': {
+            agencyId: 'WWI',
+            courtId: 'CLDN',
+            date: '2020-11-20T00:00:00',
+            startTime: '2020-11-20T11:00:00',
+            endTime: '2020-11-20T14:00:00',
+            preLocation: '2',
+            mainLocation: '1',
+            postLocation: '3',
+            preRequired: 'true',
+            postRequired: 'true',
+          },
+        },
+      })
+
+      availabilityCheckService.getAvailability.mockResolvedValue({
+        isAvailable: true,
+        alternatives: [],
+        totalInterval: { start: '11:00', end: '14:00' },
+      })
+
+      await controller.view()(req, res, null)
+
+      expect(res.redirect).toHaveBeenCalledWith('/change-video-link/123')
+    })
+
     it('should render the page', async () => {
       const req = mockRequest({
         params: { bookingId: '123' },

--- a/backend/routes/amendBooking/videoLinkNotAvailableController.ts
+++ b/backend/routes/amendBooking/videoLinkNotAvailableController.ts
@@ -21,10 +21,14 @@ export default class VideoLinkNotAvailableController {
         return res.redirect(`/booking-details/${bookingId}`)
       }
 
-      const { alternatives } = await this.availabilityCheckService.getAvailability(res.locals, {
+      const { alternatives, isAvailable } = await this.availabilityCheckService.getAvailability(res.locals, {
         videoBookingId: parseInt(bookingId, 10),
         ...update,
       })
+
+      if (isAvailable) {
+        return res.redirect(`/change-video-link/${bookingId}`)
+      }
 
       return res.render('amendBooking/videoLinkNotAvailable.njk', {
         alternatives: alternatives.map(a => {

--- a/backend/routes/createBooking/notAvailable/NotAvailableController.test.ts
+++ b/backend/routes/createBooking/notAvailable/NotAvailableController.test.ts
@@ -69,6 +69,27 @@ describe('Not available page', () => {
       })
     })
 
+    it('should redirect back to booking search page if have since selected an available option', async () => {
+      const req = mockRequest({
+        params: {
+          offenderNo: 'A12345',
+          agencyId: 'MDI',
+        },
+        body: {},
+        signedCookies,
+      })
+
+      availabilityCheckService.getAvailability.mockResolvedValue({
+        isAvailable: true,
+        alternatives: [],
+        totalInterval: { start: '11:00', end: '14:00' },
+      })
+
+      await controller.view(req, res, null)
+
+      expect(res.redirect).toHaveBeenCalledWith('/MDI/offenders/A12345/add-court-appointment')
+    })
+
     it('should render template with data', async () => {
       const req = mockRequest({
         params: {

--- a/backend/routes/createBooking/notAvailable/NotAvailableController.ts
+++ b/backend/routes/createBooking/notAvailable/NotAvailableController.ts
@@ -18,10 +18,14 @@ export default class NotAvailableController {
 
     const newBooking = getNewBooking(req)
 
-    const { alternatives } = await this.availabilityCheckService.getAvailability(res.locals, {
+    const { alternatives, isAvailable } = await this.availabilityCheckService.getAvailability(res.locals, {
       agencyId,
       ...newBooking,
     })
+
+    if (isAvailable) {
+      return res.redirect(`/${agencyId}/offenders/${offenderNo}/add-court-appointment`)
+    }
 
     return res.render('createBooking/notAvailable.njk', {
       alternatives: alternatives.map(a => {

--- a/views/viewBookings/bookingDetails.njk
+++ b/views/viewBookings/bookingDetails.njk
@@ -72,7 +72,7 @@
 <div class="govuk-button-group">
   {{ govukButton({
     text: "Change booking details",
-    href: '/change-video-link/' + bookingDetails.videoBookingId,
+    href: '/start-change-booking/' + bookingDetails.videoBookingId,
     attributes: { "data-qa": "change-booking" }
   }) }}
 

--- a/views/viewBookings/index.njk
+++ b/views/viewBookings/index.njk
@@ -28,7 +28,7 @@
           { html: (item.prisonLocation | escape)+ '<br/>in: ' + (item.prison | escape) },
           { text: item.court },
           { text: hearingDescriptions[item.hearingType] },
-          { html: '<a class="govuk-link" href="/booking-details/' + item.videoLinkBookingId + '">Change</a>' if item.hearingType == 'MAIN' else ''}
+          { html: '<a class="govuk-link" href="/start-change-booking/' + item.videoLinkBookingId + '">Change</a>' if item.hearingType == 'MAIN' else ''}
         ]
       ), rows) %}
   {% endfor %}

--- a/views/viewBookings/index.njk
+++ b/views/viewBookings/index.njk
@@ -28,7 +28,7 @@
           { html: (item.prisonLocation | escape)+ '<br/>in: ' + (item.prison | escape) },
           { text: item.court },
           { text: hearingDescriptions[item.hearingType] },
-          { html: '<a class="govuk-link" href="/start-change-booking/' + item.videoLinkBookingId + '">Change</a>' if item.hearingType == 'MAIN' else ''}
+          { html: '<a class="govuk-link" href="/booking-details/' + item.videoLinkBookingId + '">Change</a>' if item.hearingType == 'MAIN' else ''}
         ]
       ), rows) %}
   {% endfor %}


### PR DESCRIPTION
When creating or amending a booking at a time that conflicts with another booking, after selecting an alternative and clicking back, the user was previously presented a not available page. Now redirecting back to the appropriate 'enter details' page (as the booking is actually present)

Also fixing issue where we were entering the edit booking flow by the wrong entry point. Needed to go via 'start-editing-booking so any previous cookie state would be cleared out. This was instead potentially showing the wrong booking