### PR TITLE
DCS-976 Analytics. Push video link booking events to Google sheets.

### DIFF
--- a/helm_deploy/hmpps-book-video-link/templates/job.yaml
+++ b/helm_deploy/hmpps-book-video-link/templates/job.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: update-events-job


### PR DESCRIPTION
Cluster doesn't like `apiVersion: batch/v1` in job.yaml and refuses to deploy to 'dev'.  Use `apiVersion: batch/v1beta1` instead.
This isn't picked up by `helm lint`. 