### PR TITLE
DCS-1097 fixed some alignment issues

### DIFF
--- a/views/amendBooking/changeVideoLinkBooking.njk
+++ b/views/amendBooking/changeVideoLinkBooking.njk
@@ -23,7 +23,7 @@
 
 {% block content %}
 
-    <div class="govuk-grid-row govuk-!-padding-left-6">
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
             {% if errors.length > 0 %}
@@ -40,13 +40,13 @@
             {{
                 govukSummaryList({
                 classes: 'govuk-summary-list--no-border govuk-!-margin-bottom-0',
-                rows: prisoner | toSummaryViewModel | removePaddingBottom
+                rows: prisoner | toSummaryViewModel
                 })
             }}
             {{
                 govukSummaryList({
                 classes: 'govuk-summary-list--no-border govuk-!-margin-bottom-0',
-                rows: locations | toSummaryViewModel | removePaddingBottom
+                rows: locations | toSummaryViewModel 
                 })
             }}
             {% if courts.length === 1 %}
@@ -67,7 +67,7 @@
         </div>
     </div>
 
-    <div class="govuk-grid-row govuk-!-padding-left-6">
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <form method="POST" novalidate="novalidate">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
@@ -82,7 +82,7 @@
                         classes: "qa-court-value",
                         label: {
                             text: "Which court is the hearing for?",
-                            classes: "govuk-!-margin-top-8"
+                            classes: "govuk-!-margin-top-6"
                             },
                         items: courts | setSelected(form.courtId),
                         errorMessage: errors | findError("courtId")

--- a/views/createBooking/newBooking.njk
+++ b/views/createBooking/newBooking.njk
@@ -39,7 +39,7 @@
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
                     {{ govukSummaryList({
-                        classes: "govuk-summary-list--no-border",
+                        classes: "govuk-summary-list--no-border govuk-!-margin-bottom-0",
                         rows: [
                             {
                                 key: {
@@ -59,6 +59,21 @@
                             }
                         ]
                     }) }}
+                    {% if courts.length === 1 %}
+                    {{ govukSummaryList({
+                        classes: "govuk-summary-list--no-border",
+                        rows: [{
+                            key: {
+                                text: "Court",
+                                classes: "qa-court-key govuk-!-padding-bottom-0"
+                            },
+                        value: {
+                            text: courts[0].name,
+                            classes: "qa-court-value govuk-!-padding-bottom-0"
+                            }
+                        }]
+                    }) }}
+                    {% endif %}    
                 </div>
             </div>
 
@@ -68,26 +83,14 @@
 
                 {% if courts.length === 1 %}
                     <input type="hidden" name="courtId" value="{{ courts[0].id }}" />
-                    {{ govukSummaryList({
-                        classes: "govuk-summary-list--no-border",
-                        rows: [{
-                            key: {
-                                text: "Court",
-                                classes: "govuk-summary-list__key qa-court-key govuk-!-padding-bottom-0 govuk-!-width-one-half"
-                                },
-                            value: {
-                                text: courts[0].name,
-                                classes: "govuk-summary-list__value qa-court-value govuk-!-padding-bottom-0 govuk-!-width-one-half"
-                                }
-                            }]
-                    }) }}    
                 {% else %}
                     {{ govukSelect({
                         name: "courtId",
                         id: "courtId",
                         classes: "qa-court-value",
                         label: {
-                            text: "Which court is the hearing for?"
+                            text: "Which court is the hearing for?",
+                            classes: "govuk-!-margin-top-6"
                         },
                         items: courts | toSelect('id', 'name', formValues.courtId),
                         errorMessage: errors | findError("courtId")


### PR DESCRIPTION
Noticed that when a user has a single preferred court the court in the summary list is not aligned. 
<img width="1296" alt="Screenshot 2021-07-23 at 11 46 48" src="https://user-images.githubusercontent.com/48809053/126779495-23620a0e-a270-44da-984b-c30f0674b1ac.png">

Fixed:
<img width="793" alt="Screenshot 2021-07-23 at 12 48 56" src="https://user-images.githubusercontent.com/48809053/126779598-5f208774-794c-4444-8598-e139319625af.png">

Also noticed that the content of the Change change video link booking page was not aligned with the logo and service name as in the prototype:
<img width="913" alt="Screenshot 2021-07-23 at 12 49 14" src="https://user-images.githubusercontent.com/48809053/126779980-83d1ae04-6584-4e81-9aab-cc8d7967d3b1.png">

Fixed by removing some left padding:
<img width="762" alt="Screenshot 2021-07-23 at 13 01 31" src="https://user-images.githubusercontent.com/48809053/126779829-1310e112-9ac3-4302-b71a-f85d543c9bcc.png">


