### PR TITLE
DCS-1020 fixed collapsed form in prisoner search by pnc number

### DIFF
--- a/backend/routes/createBooking/prisonerSearch/prisonerSearchController.ts
+++ b/backend/routes/createBooking/prisonerSearch/prisonerSearchController.ts
@@ -62,7 +62,7 @@ export default class PrisonerSearchController {
             }
           }),
         hasSearched,
-        hasOtherSearchDetails: prisonNumber || dobDay || dobMonth || dobYear || prison,
+        hasOtherSearchDetails: prisonNumber || pncNumber,
       })
     }
   }


### PR DESCRIPTION
Adjusted hasOtherSearchDetails in prisonerSearchController so that when you search for a prisoner using either prison number or PNC number the collapsed part of the form will now stay open when results are displayed. Previously this was only remaining open for a prison number search. 

<img width="1180" alt="Screenshot 2021-08-02 at 11 25 28" src="https://user-images.githubusercontent.com/48809053/127847255-755dd808-19c9-4d27-9eb7-504eda530383.png">

<img width="1179" alt="Screenshot 2021-08-02 at 11 25 52" src="https://user-images.githubusercontent.com/48809053/127847273-330e2179-4e21-4123-a420-00fcc462f5f0.png">

(Also fixed so that it wouldn't open up when searching by prison/dob which have inputs outside of the collapsed form section). 