### PR TITLE
DCS-1136: no longer using prioritised matching

### DIFF
--- a/backend/api/prisonApi.ts
+++ b/backend/api/prisonApi.ts
@@ -54,7 +54,6 @@ export default class PrisonApi {
       dob: dateOfBirth,
       partialNameMatch: false,
       includeAliases,
-      prioritisedMatch: true,
     })
     return this.get(context, `/api/prisoners?${searchParams}`, resultsLimit)
   }


### PR DESCRIPTION
If prisoner number or PNC numbers were incorrect then the prioritisedMatch was causing all prisoners to be returned which is the wrong result.
So prioritisedMatch removed. It will default to the value of false.