### PR TITLE
DCS-1583 - booking request throws an error

### DIFF
--- a/backend/api/prisonRegisterApi.test.ts
+++ b/backend/api/prisonRegisterApi.test.ts
@@ -19,9 +19,9 @@ describe('prisonRegisterApi', () => {
       expect(await api.getVideoLinkConferencingCentreEmailAddress({}, 'MDI')).toEqual('vcc@def')
     })
 
-    it('VCC email address not found', async () => {
-      mock.get('/secure/prisons/id/MDI/videolink-conferencing-centre/email-address').reply(404, {})
-      await expect(api.getVideoLinkConferencingCentreEmailAddress({}, 'MDI')).rejects.toThrow(new Error('Not Found'))
+    it('VCC email address not found - returns 404 error', async () => {
+      mock.get('/secure/prisons/id/MDI/videolink-conferencing-centre/email-address').reply(404)
+      await expect(api.getVideoLinkConferencingCentreEmailAddress({}, 'MDI')).resolves.toBe(undefined)
     })
   })
 
@@ -31,9 +31,9 @@ describe('prisonRegisterApi', () => {
       expect(await api.getOffenderManagementUnitEmailAddress({}, 'MDI')).toEqual('omu@def')
     })
 
-    it('OMU email address not found', async () => {
-      mock.get('/secure/prisons/id/MDI/offender-management-unit/email-address').reply(404, {})
-      await expect(api.getOffenderManagementUnitEmailAddress({}, 'MDI')).rejects.toThrow(new Error('Not Found'))
+    it('OMU email address not found - returns 404 error', async () => {
+      mock.get('/secure/prisons/id/MDI/offender-management-unit/email-address').reply(404)
+      await expect(api.getOffenderManagementUnitEmailAddress({}, 'MDI')).resolves.toBe(undefined)
     })
   })
 })

--- a/backend/api/prisonRegisterApi.ts
+++ b/backend/api/prisonRegisterApi.ts
@@ -4,10 +4,10 @@ import Client, { Context } from './oauthEnabledClient'
 export default class PrisonRegisterApi {
   constructor(private readonly client: Client) {}
 
-  private processStringResponse = (response: Response): string => response.text
+  private processStringResponse = (response: Response): string => response?.text
 
   private getString(context: Context, url: string): Promise<string> {
-    return this.client.get(context, url).then(response => this.processStringResponse(response))
+    return this.client.getPotential(context, url).then(response => this.processStringResponse(response))
   }
 
   public getVideoLinkConferencingCentreEmailAddress(context: Context, prisonId: string): Promise<string> {

--- a/backend/services/notificationService.test.ts
+++ b/backend/services/notificationService.test.ts
@@ -187,6 +187,19 @@ describe('Notification service', () => {
         }
       )
     })
+
+    it('Should throw error', async () => {
+      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      notifyApi.sendEmail.mockRejectedValue(new Error('Network error'))
+
+      await expect(
+        notificationService.sendBookingRequestEmails(context, 'A_USER', {
+          ...requestEmail,
+          courtEmailAddress: undefined,
+        })
+      ).rejects.toThrow()
+    })
   })
 
   describe('Send update emails', () => {
@@ -803,6 +816,26 @@ describe('Notification service', () => {
           reference: null,
         }
       )
+    })
+
+    it('fails to get emailAddress on prisonApi exception', async () => {
+      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      notifyApi.sendEmail.mockResolvedValue({})
+
+      prisonRegisterApi.getOffenderManagementUnitEmailAddress.mockRejectedValue(new Error('Network error'))
+      const result = await notificationService.sendBookingCreationEmails(context, 'A_USER', createEmail)
+      expect(result).toBe(undefined)
+    })
+
+    it('fails to send email on Notify exception', async () => {
+      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      notifyApi.sendEmail.mockRejectedValue(new Error('Network error'))
+
+      prisonRegisterApi.getOffenderManagementUnitEmailAddress.mockResolvedValue('some email address')
+      const result = await notificationService.sendBookingCreationEmails(context, 'A_USER', createEmail)
+      expect(result).toBe(undefined)
     })
   })
 })


### PR DESCRIPTION
The request booking journey will throw an error if unable to send an email to either prison or court.
The prisonRegisterApi.getString method has been changed to use getPotential rather than get because getPotential already has exception handling.