### PR TITLE
MAP-257 update dependencies and assign type to error handler

### DIFF
--- a/backend/middleware/errorHandler.test.ts
+++ b/backend/middleware/errorHandler.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from 'express'
+import { HttpError } from 'http-errors'
 import errorHandler from './errorHandler'
 import { logError } from '../logError'
 
@@ -15,7 +16,7 @@ describe('Error handling middleware', () => {
     render: jest.fn(),
     locals: {} as Record<string, unknown>,
   }
-  const error = new Error('error message')
+  const error = new Error('error message') as HttpError<number>
   const production = false
 
   const handleErrorWhenRetryLinkIs = redirectUrl =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "@typescript-eslint/parser": "^5.59.5",
         "audit-ci": "^6.6.1",
         "concurrently": "^7.6.0",
-        "cypress": "^12.17.3",
+        "cypress": "^12.17.4",
         "cypress-multi-reporters": "^1.6.3",
         "dotenv-expand": "^10.0.0",
         "eslint": "^8.40.0",
@@ -5004,13 +5004,13 @@
       "integrity": "sha512-cTXY6iy0gN5Ha/cGILeDgQE+nKiKDU2m0DjSRdJhr86BN3cM7oefBsTk2aH0LQeaYtL7Z7HvW+jYoadmdhzeDA=="
     },
     "node_modules/cypress": {
-      "version": "12.17.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.3.tgz",
-      "integrity": "sha512-/R4+xdIDjUSLYkiQfwJd630S81KIgicmQOLXotFxVXkl+eTeVO+3bHXxdi5KBh/OgC33HWN33kHX+0tQR/ZWpg==",
+      "version": "12.17.4",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.4.tgz",
+      "integrity": "sha512-gAN8Pmns9MA5eCDFSDJXWKUpaL3IDd89N9TtIupjYnzLSmlpVr+ZR+vb4U/qaMp+lB6tBvAmt7504c3Z4RU5KQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.11",
+        "@cypress/request": "2.88.12",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -5045,6 +5045,7 @@
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
@@ -10667,6 +10668,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/prompts": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@typescript-eslint/parser": "^5.59.5",
     "audit-ci": "^6.6.1",
     "concurrently": "^7.6.0",
-    "cypress": "^12.17.3",
+    "cypress": "^12.17.4",
     "cypress-multi-reporters": "^1.6.3",
     "dotenv-expand": "^10.0.0",
     "eslint": "^8.40.0",
@@ -84,6 +84,7 @@
   },
   "overrides": {
     "cypress": {
+      "request": "3.0.0",
       "tough-cookie": "4.1.3"
     }
   },


### PR DESCRIPTION
to fix this hopefully!

Found vulnerable advisory paths:
GHSA-p8p7-x288-28g6|cypress>@cypress/request
Failed security audit due to moderate vulnerabilities.
Vulnerable advisories are:
https://github.com/advisories/GHSA-p8p7-x288-28g6