### PR TITLE
MAP-342: Update CronJob to use batch/v1

### DIFF
--- a/helm_deploy/hmpps-book-video-link/templates/job.yaml
+++ b/helm_deploy/hmpps-book-video-link/templates/job.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ template "app.name" . }}-update-events


### PR DESCRIPTION
batch/v1beta1 is deprecated and will be removed in k8s 1.25