### PR TITLE
MAP-306: Use HMPPS Manage Users API for user details etc.

### DIFF
--- a/backend/api/index.ts
+++ b/backend/api/index.ts
@@ -9,6 +9,7 @@ import { oauthApiFactory } from './oauthApi'
 import { tokenVerificationApiFactory } from './tokenVerificationApi'
 import { notifyApi } from './notifyApi'
 import UserCourtPreferencesApi from './userCourtPreferencesApi'
+import ManageUsersApi from './manageUsersApi'
 
 const userCourtPreferencesApi = new UserCourtPreferencesApi(
   new Client({
@@ -38,13 +39,14 @@ const prisonerOffenderSearchApi = new PrisonerOffenderSearchApi(
   })
 )
 
-const oauthApi = oauthApiFactory(
+const manageUsersApi = new ManageUsersApi(
   new Client({
-    baseUrl: config.apis.oauth2.url,
-    timeout: config.apis.oauth2.timeoutSeconds * 1000,
-  }),
-  { ...config.apis.oauth2 }
+    baseUrl: config.apis.manageUsers.url,
+    timeout: config.apis.manageUsers.timeoutSeconds * 1000,
+  })
 )
+
+const oauthApi = oauthApiFactory({ ...config.apis.oauth2 })
 
 const tokenVerificationApi = tokenVerificationApiFactory(
   new Client({
@@ -64,6 +66,7 @@ export const apis = {
   userCourtPreferencesApi,
   notifyApi,
   oauthApi,
+  manageUsersApi,
   prisonApi,
   prisonRegisterApi,
   prisonerOffenderSearchApi,

--- a/backend/api/manageUsersApi.test.ts
+++ b/backend/api/manageUsersApi.test.ts
@@ -1,0 +1,71 @@
+import nock from 'nock'
+
+import Client from './oauthEnabledClient'
+import ManageUsersApi from './manageUsersApi'
+
+const baseUrl = 'http://localhost:8080'
+
+describe('court api tests', () => {
+  const client = new Client({ baseUrl, timeout: 2000 })
+  const manageUsersApi = new ManageUsersApi(client)
+  const mock = nock(baseUrl)
+
+  const userDetails = {
+    username: 'DEMO_USER1',
+    active: false,
+    name: 'John Smith',
+    authSource: 'nomis',
+    staffId: 231232,
+    activeCaseLoadId: 'MDI',
+    userId: '231232',
+    uuid: '5105a589-75b3-4ca0-9433-b96228c1c8f3',
+  }
+
+  const emailAddress = {
+    username: 'DEMO_USER1',
+    email: 'demo.user@nomis.com',
+    verified: true,
+  }
+
+  const userRoles = [{ roleCode: 'GLOBAL_SEARCH' }]
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe('currentUser', () => {
+    it("Gets the current user's details", async () => {
+      mock.get('/users/me').reply(200, userDetails)
+
+      const data = await manageUsersApi.currentUser({})
+      expect(data).toEqual(userDetails)
+    })
+  })
+
+  describe('userRoles', () => {
+    it("Gets the current user's roles", async () => {
+      mock.get('/users/me/roles').reply(200, userRoles)
+
+      const data = await manageUsersApi.userRoles({})
+      expect(data).toEqual(userRoles)
+    })
+  })
+
+  describe('userEmail', () => {
+    it("Gets the specified user's email address", async () => {
+      mock.get('/users/DEMO_USER1/email').reply(200, emailAddress)
+
+      const data = await manageUsersApi.userEmail({}, 'DEMO_USER1')
+      expect(data).toEqual(emailAddress)
+    })
+  })
+
+  describe('userDetails', () => {
+    it("Gets the specified user's details", async () => {
+      mock.get('/users/DEMO_USER1').reply(200, userDetails)
+
+      const data = await manageUsersApi.userDetails({}, 'DEMO_USER1')
+      expect(data).toEqual(userDetails)
+    })
+  })
+})

--- a/backend/api/manageUsersApi.ts
+++ b/backend/api/manageUsersApi.ts
@@ -1,0 +1,59 @@
+import { Response } from 'superagent'
+import contextProperties from '../contextProperties'
+import Client, { Context } from './oauthEnabledClient'
+
+export type UserDetails = {
+  username: string
+  active: boolean
+  name: string
+  authSource: string
+  staffId?: number
+  activeCaseLoadId?: string
+  userId: string
+  uuid?: string
+}
+
+export type User = {
+  username: string
+}
+
+export type Role = {
+  roleCode: string
+}
+
+export type EmailAddress = {
+  username: string
+  email?: string
+  verified: boolean
+}
+
+export default class ManageUsersApi {
+  constructor(private readonly client: Client) {}
+
+  private processResponse<T>(context: Context): (Response) => T {
+    return (response: Response) => {
+      contextProperties.setResponsePagination(context, response.headers)
+      return response.body
+    }
+  }
+
+  private get<T>(context: Context, url: string): Promise<T> {
+    return this.client.get(context, url).then(this.processResponse(context))
+  }
+
+  public currentUser(context: Context): Promise<User> {
+    return this.get(context, `/users/me`)
+  }
+
+  public userRoles(context: Context): Promise<Role[]> {
+    return this.get(context, `/users/me/roles`)
+  }
+
+  public userEmail(context: Context, username: string): Promise<EmailAddress> {
+    return this.get(context, `/users/${username}/email`)
+  }
+
+  public userDetails(context: Context, username: string): Promise<UserDetails> {
+    return this.get(context, `/users/${username}`)
+  }
+}

--- a/backend/api/oauthApi.js
+++ b/backend/api/oauthApi.js
@@ -15,13 +15,7 @@ const apiClientCredentials = (clientId, clientSecret) => Buffer.from(`${clientId
  * @param {string} params.url
  * @returns a configured oauthApi instance
  */
-const oauthApiFactory = (client, { clientId, clientSecret, url }) => {
-  const get = (context, path) => client.get(context, path).then(response => response.body)
-  const currentUser = context => get(context, '/api/user/me')
-  const userRoles = context => get(context, '/api/user/me/roles')
-  const userEmail = (context, username) => get(context, `/api/user/${username}/email`)
-  const userDetails = (context, username) => get(context, `/api/user/${username}`)
-
+const oauthApiFactory = ({ clientId, clientSecret, url }) => {
   const oauthAxios = axios.create({
     baseURL: `${url}oauth/token`,
     method: 'post',
@@ -65,10 +59,6 @@ const oauthApiFactory = (client, { clientId, clientSecret, url }) => {
     makeTokenRequest(querystring.stringify({ refresh_token: refreshToken, grant_type: 'refresh_token' }), 'refresh:')
 
   return {
-    currentUser,
-    userRoles,
-    userEmail,
-    userDetails,
     refresh,
   }
 }

--- a/backend/api/oauthApi.test.js
+++ b/backend/api/oauthApi.test.js
@@ -5,8 +5,7 @@ const clientId = 'clientId'
 const url = 'http://localhost/'
 const clientSecret = 'clientSecret'
 
-const client = jest.fn()
-const oauthApi = oauthApiFactory(client, { url, clientId, clientSecret })
+const oauthApi = oauthApiFactory({ url, clientId, clientSecret })
 const mock = nock('http://localhost', { reqheaders: { 'Content-Type': 'application/x-www-form-urlencoded' } })
 
 describe('oathApi tests', () => {

--- a/backend/config.js
+++ b/backend/config.js
@@ -39,6 +39,10 @@ module.exports = {
       systemId: process.env.API_SYSTEM_ID || 'book-video-link-system',
       systemSecret: process.env.API_SYSTEM_SECRET || 'systemsecret',
     },
+    manageUsers: {
+      url: process.env.MANAGE_USERS_API_URL || 'http://localhost:9091/',
+      timeoutSeconds: toInt(process.env.MANAGE_USERS_API_TIMEOUT_SECONDS, 30),
+    },
     prison: {
       url: process.env.API_ENDPOINT_URL || 'http://localhost:8080/',
       timeoutSeconds: toInt(process.env.API_ENDPOINT_TIMEOUT_SECONDS, 30),

--- a/backend/middleware/currentUser.test.ts
+++ b/backend/middleware/currentUser.test.ts
@@ -1,7 +1,7 @@
 import currentUser from './currentUser'
 import ManageCourtsService from '../services/manageCourtsService'
 
-const oauthApi = {
+const manageUsersApi = {
   currentUser: jest.fn(),
   userRoles: jest.fn(),
 }
@@ -32,15 +32,15 @@ describe('Current user', () => {
 
   beforeEach(() => {
     jest.resetAllMocks()
-    oauthApi.currentUser = jest.fn()
-    oauthApi.userRoles = jest.fn()
+    manageUsersApi.currentUser = jest.fn()
+    manageUsersApi.userRoles = jest.fn()
 
-    oauthApi.currentUser.mockReturnValue({
+    manageUsersApi.currentUser.mockReturnValue({
       name: 'Bob Smith',
       username: 'USER_BOB',
     })
 
-    oauthApi.userRoles.mockReturnValue([{ roleCode: 'ROLE_A' }, { roleCode: 'ROLE_B' }, { roleCode: 'ROLE_C' }])
+    manageUsersApi.userRoles.mockReturnValue([{ roleCode: 'ROLE_A' }, { roleCode: 'ROLE_B' }, { roleCode: 'ROLE_C' }])
 
     req = { session: {}, protocol: 'http', originalUrl: '/somethingelse', get: jest.fn() }
 
@@ -48,11 +48,11 @@ describe('Current user', () => {
   })
 
   it('should request and store user details', async () => {
-    const controller = currentUser(oauthApi, manageCourtsService)
+    const controller = currentUser(manageUsersApi, manageCourtsService)
 
     await controller(req, res, next)
 
-    expect(oauthApi.currentUser).toHaveBeenCalled()
+    expect(manageUsersApi.currentUser).toHaveBeenCalled()
     expect(req.session.userDetails).toEqual({
       name: 'Bob Smith',
       username: 'USER_BOB',
@@ -60,16 +60,16 @@ describe('Current user', () => {
   })
 
   it('should request and store user roles to session', async () => {
-    const controller = currentUser(oauthApi, manageCourtsService)
+    const controller = currentUser(manageUsersApi, manageCourtsService)
 
     await controller(req, res, next)
 
-    expect(oauthApi.userRoles).toHaveBeenCalled()
+    expect(manageUsersApi.userRoles).toHaveBeenCalled()
     expect(req.session.userRoles).toEqual([{ roleCode: 'ROLE_A' }, { roleCode: 'ROLE_B' }, { roleCode: 'ROLE_C' }])
   })
 
   it('should call get', async () => {
-    const controller = currentUser(oauthApi, manageCourtsService)
+    const controller = currentUser(manageUsersApi, manageCourtsService)
     const get = jest.fn().mockReturnValue('someHost')
     req = { session: {}, protocol: 'http', originalUrl: '/somethingelse', get }
 
@@ -78,7 +78,7 @@ describe('Current user', () => {
     expect(get).toHaveBeenCalledWith('host')
   })
   it('should stash user data into res.locals', async () => {
-    const controller = currentUser(oauthApi, manageCourtsService)
+    const controller = currentUser(manageUsersApi, manageCourtsService)
     const get = jest.fn().mockReturnValue('someHost')
     req = { session: {}, protocol: 'http', originalUrl: '/somethingelse', get }
 
@@ -93,7 +93,7 @@ describe('Current user', () => {
   })
 
   it('should stash userRole data into res.locals', async () => {
-    const controller = currentUser(oauthApi, manageCourtsService)
+    const controller = currentUser(manageUsersApi, manageCourtsService)
 
     await controller(req, res, next)
 
@@ -102,7 +102,7 @@ describe('Current user', () => {
 
   it('should stash preferredCourts data into res.locals when a user has selected preferred courts', async () => {
     manageCourtsService.getSelectedCourts.mockResolvedValue(courtList)
-    const controller = currentUser(oauthApi, manageCourtsService)
+    const controller = currentUser(manageUsersApi, manageCourtsService)
 
     await controller(req, res, next)
 
@@ -111,7 +111,7 @@ describe('Current user', () => {
 
   it('should stash an empty array of no preferredCourts data into res.locals when a user has not selected preferred courts', async () => {
     manageCourtsService.getSelectedCourts.mockResolvedValue([])
-    const controller = currentUser(oauthApi, manageCourtsService)
+    const controller = currentUser(manageUsersApi, manageCourtsService)
 
     await controller(req, res, next)
 
@@ -119,12 +119,12 @@ describe('Current user', () => {
   })
 
   it('ignore xhr requests', async () => {
-    const controller = currentUser(oauthApi, manageCourtsService)
+    const controller = currentUser(manageUsersApi, manageCourtsService)
     req.xhr = true
 
     await controller(req, res, next)
 
-    expect(oauthApi.currentUser.mock.calls.length).toEqual(0)
+    expect(manageUsersApi.currentUser.mock.calls.length).toEqual(0)
     expect(next).toHaveBeenCalled()
   })
 })

--- a/backend/middleware/currentUser.ts
+++ b/backend/middleware/currentUser.ts
@@ -4,14 +4,14 @@ import { forenameToInitial } from '../utils'
 import config from '../config'
 import ManageCourtsService from '../services/manageCourtsService'
 
-export default (oauthApi, manageCourtsService: ManageCourtsService): RequestHandler =>
+export default (manageUsersApi, manageCourtsService: ManageCourtsService): RequestHandler =>
   async (req, res, next) => {
     if (!req.xhr) {
       if (!req.session.userDetails) {
-        req.session.userDetails = await oauthApi.currentUser(res.locals)
+        req.session.userDetails = await manageUsersApi.currentUser(res.locals)
       }
       if (!req.session.userRoles) {
-        req.session.userRoles = await oauthApi.userRoles(res.locals)
+        req.session.userRoles = await manageUsersApi.userRoles(res.locals)
       }
 
       if (typeof req.csrfToken === 'function') {

--- a/backend/services/index.ts
+++ b/backend/services/index.ts
@@ -10,6 +10,7 @@ import AvailabilityCheckService from './availabilityCheckService'
 
 const {
   oauthApi,
+  manageUsersApi,
   whereaboutsApi,
   prisonApi,
   notifyApi,
@@ -18,7 +19,7 @@ const {
   prisonRegisterApi,
 } = apis
 
-const notificationService = new NotificationService(oauthApi, notifyApi, prisonRegisterApi)
+const notificationService = new NotificationService(manageUsersApi, notifyApi, prisonRegisterApi)
 const availabilityCheckService = new AvailabilityCheckService(whereaboutsApi)
 
 const manageCourtsService = new ManageCourtsService(whereaboutsApi, userCourtPreferencesApi)

--- a/backend/services/notificationService.test.ts
+++ b/backend/services/notificationService.test.ts
@@ -6,7 +6,7 @@ import PrisonRegisterApi from '../api/prisonRegisterApi'
 
 jest.mock('../api/prisonRegisterApi')
 
-const oauthApi = {
+const manageUsersApi = {
   userDetails: jest.fn(),
   userEmail: jest.fn(),
 }
@@ -22,7 +22,7 @@ describe('Notification service', () => {
   let notificationService: NotificationService
 
   beforeEach(() => {
-    notificationService = new NotificationService(oauthApi, notifyApi, prisonRegisterApi)
+    notificationService = new NotificationService(manageUsersApi, notifyApi, prisonRegisterApi)
     prisonRegisterApi.getOffenderManagementUnitEmailAddress.mockResolvedValue('omu@prison.com')
     prisonRegisterApi.getVideoLinkConferencingCentreEmailAddress.mockResolvedValue('vlb@prison.com')
   })
@@ -49,19 +49,19 @@ describe('Notification service', () => {
     }
 
     it('Details are retrieved for user', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingRequestEmails(context, 'A_USER', requestEmail)
 
-      expect(oauthApi.userEmail).toHaveBeenCalledWith({}, 'A_USER')
-      expect(oauthApi.userDetails).toHaveBeenCalledWith({}, 'A_USER')
+      expect(manageUsersApi.userEmail).toHaveBeenCalledWith({}, 'A_USER')
+      expect(manageUsersApi.userDetails).toHaveBeenCalledWith({}, 'A_USER')
     })
 
     it('should send personalisation with optional fields', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingRequestEmails(context, 'A_USER', {
@@ -96,8 +96,8 @@ describe('Notification service', () => {
     })
 
     it('should send email to Prison Video Link Booking Admin', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingRequestEmails(context, 'A_USER', requestEmail)
@@ -126,8 +126,8 @@ describe('Notification service', () => {
     })
 
     it('Should send email to court', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingRequestEmails(context, 'A_USER', requestEmail)
@@ -156,8 +156,8 @@ describe('Notification service', () => {
       )
     })
     it('Should not send court email address', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingRequestEmails(context, 'A_USER', {
@@ -189,8 +189,8 @@ describe('Notification service', () => {
     })
 
     it('Should throw error', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockRejectedValue(new Error('Network error'))
 
       await expect(
@@ -218,19 +218,19 @@ describe('Notification service', () => {
     }
 
     it('Details are retrieved for user', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingUpdateEmails(context, 'A_USER', updateEmail)
 
-      expect(oauthApi.userEmail).toHaveBeenCalledWith({}, 'A_USER')
-      expect(oauthApi.userDetails).toHaveBeenCalledWith({}, 'A_USER')
+      expect(manageUsersApi.userEmail).toHaveBeenCalledWith({}, 'A_USER')
+      expect(manageUsersApi.userDetails).toHaveBeenCalledWith({}, 'A_USER')
     })
 
     it('should send personalisation with optional fields', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingUpdateEmails(context, 'A_USER', {
@@ -262,8 +262,8 @@ describe('Notification service', () => {
     })
 
     it('should send email to Offender Management Unit', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingUpdateEmails(context, 'A_USER', updateEmail)
@@ -292,8 +292,8 @@ describe('Notification service', () => {
     it('Offender Management Unit email address is optional', async () => {
       prisonRegisterApi.getOffenderManagementUnitEmailAddress.mockRejectedValue({})
 
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingUpdateEmails(context, 'A_USER', updateEmail)
@@ -314,8 +314,8 @@ describe('Notification service', () => {
     })
 
     it('should send email to Prison Video Link Booking Admin', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingUpdateEmails(context, 'A_USER', updateEmail)
@@ -341,8 +341,8 @@ describe('Notification service', () => {
       )
     })
     it('should not include court email address in email to prison', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingUpdateEmails(context, 'A_USER', {
@@ -372,8 +372,8 @@ describe('Notification service', () => {
     })
 
     it('Should send email to court', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingUpdateEmails(context, 'USER', updateEmail)
@@ -438,19 +438,19 @@ describe('Notification service', () => {
     }
 
     it('Details are retrieved for user', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendCancellationEmails(context, 'A_USER', bookingDetail)
 
-      expect(oauthApi.userEmail).toHaveBeenCalledWith({}, 'A_USER')
-      expect(oauthApi.userDetails).toHaveBeenCalledWith({}, 'A_USER')
+      expect(manageUsersApi.userEmail).toHaveBeenCalledWith({}, 'A_USER')
+      expect(manageUsersApi.userDetails).toHaveBeenCalledWith({}, 'A_USER')
     })
 
     it('should send personalisation with optional fields', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendCancellationEmails(context, 'A_USER', {
@@ -482,8 +482,8 @@ describe('Notification service', () => {
     })
 
     it('should send email to Offender Management Unit', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendCancellationEmails(context, 'A_USER', bookingDetail)
@@ -512,8 +512,8 @@ describe('Notification service', () => {
     it('Offender Management Unit email address is optional', async () => {
       prisonRegisterApi.getOffenderManagementUnitEmailAddress.mockRejectedValue({})
 
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendCancellationEmails(context, 'A_USER', bookingDetail)
@@ -534,8 +534,8 @@ describe('Notification service', () => {
     })
 
     it('should send email to Prison Video Link Booking Admin', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendCancellationEmails(context, 'A_USER', bookingDetail)
@@ -562,8 +562,8 @@ describe('Notification service', () => {
     })
 
     it('should not send email to Prison Video Link Booking Admin', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendCancellationEmails(context, 'A_USER', {
@@ -593,8 +593,8 @@ describe('Notification service', () => {
     })
 
     it('Should send email to court', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendCancellationEmails(context, 'USER', bookingDetail)
@@ -636,19 +636,19 @@ describe('Notification service', () => {
       courtEmailAddress: 'court@email.com',
     }
     it('Details are retrieved for user', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingCreationEmails(context, 'A_USER', createEmail)
 
-      expect(oauthApi.userEmail).toHaveBeenCalledWith({}, 'A_USER')
-      expect(oauthApi.userDetails).toHaveBeenCalledWith({}, 'A_USER')
+      expect(manageUsersApi.userEmail).toHaveBeenCalledWith({}, 'A_USER')
+      expect(manageUsersApi.userDetails).toHaveBeenCalledWith({}, 'A_USER')
     })
 
     it('should send personalisation with optional fields', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingCreationEmails(context, 'A_USER', {
@@ -680,8 +680,8 @@ describe('Notification service', () => {
     })
 
     it('should send email to Offender Management Unit', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingCreationEmails(context, 'A_USER', createEmail)
@@ -710,8 +710,8 @@ describe('Notification service', () => {
     it('Offender Management Unit email address is optional', async () => {
       prisonRegisterApi.getOffenderManagementUnitEmailAddress.mockRejectedValue({})
 
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingCreationEmails(context, 'A_USER', createEmail)
@@ -732,8 +732,8 @@ describe('Notification service', () => {
     })
 
     it('should send email to Prison Video Link Booking Admin', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingCreationEmails(context, 'A_USER', createEmail)
@@ -760,8 +760,8 @@ describe('Notification service', () => {
     })
 
     it('Should send email to court', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingCreationEmails(context, 'USER', createEmail)
@@ -788,8 +788,8 @@ describe('Notification service', () => {
     })
 
     it('should not include court email address in email sent to prison', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       await notificationService.sendBookingCreationEmails(context, 'A_USER', {
@@ -819,8 +819,8 @@ describe('Notification service', () => {
     })
 
     it('fails to get emailAddress on prisonApi exception', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockResolvedValue({})
 
       prisonRegisterApi.getOffenderManagementUnitEmailAddress.mockRejectedValue(new Error('Network error'))
@@ -829,8 +829,8 @@ describe('Notification service', () => {
     })
 
     it('fails to send email on Notify exception', async () => {
-      oauthApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
-      oauthApi.userDetails.mockResolvedValue({ name: 'A User' })
+      manageUsersApi.userEmail.mockResolvedValue({ email: 'user@email.com' })
+      manageUsersApi.userDetails.mockResolvedValue({ name: 'A User' })
       notifyApi.sendEmail.mockRejectedValue(new Error('Network error'))
 
       prisonRegisterApi.getOffenderManagementUnitEmailAddress.mockResolvedValue('some email address')

--- a/backend/services/notificationService.ts
+++ b/backend/services/notificationService.ts
@@ -22,7 +22,7 @@ interface UserDetails {
 
 export default class NotificationService {
   constructor(
-    private readonly oauthApi: any,
+    private readonly manageUsersApi: any,
     private readonly notifyApi: any,
     private readonly prisonRegisterApi: PrisonRegisterApi
   ) {}
@@ -36,8 +36,8 @@ export default class NotificationService {
 
   private async getUserDetails(context: Context, username: string): Promise<UserDetails> {
     const [{ email }, { name }] = await Promise.all([
-      this.oauthApi.userEmail(context, username),
-      this.oauthApi.userDetails(context, username),
+      this.manageUsersApi.userEmail(context, username),
+      this.manageUsersApi.userDetails(context, username),
     ])
     return { email, name }
   }

--- a/backend/setupCurrentUserAndRequestLogging.ts
+++ b/backend/setupCurrentUserAndRequestLogging.ts
@@ -7,9 +7,9 @@ import asyncMiddleware from './middleware/asyncMiddleware'
 import type { Services } from './services'
 import storeCurrentUrl from './middleware/storeCurrentUrl'
 
-export default function setupCurrentUserAndRequestLogging({ oauthApi, manageCourtsService }: Services): Router {
+export default function setupCurrentUserAndRequestLogging({ manageUsersApi, manageCourtsService }: Services): Router {
   const router = express.Router()
-  router.use(asyncMiddleware(currentUser(oauthApi, manageCourtsService)))
+  router.use(asyncMiddleware(currentUser(manageUsersApi, manageCourtsService)))
   router.use(storeCurrentUrl())
 
   router.use(createRequestLogger({ name: 'Book video link http', serializers: loggingSerialiser }))

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -34,6 +34,7 @@ env:
   FEATURE_FLAG_OUTAGE_BANNER_ENABLED: false
   REDIS_ENABLED: true
   VLBEVENT_EXPORT_SPREADSHEET_ID: "18BcOjlGlVfK8Qr3V3fhqdfYj4XEUfQGRIcJwzJ3BB-Y"
+  MANAGE_USERS_API_URL: https://manage-users-api-dev.hmpps.service.justice.gov.uk/
 
 jobs:
   cronspec: "59 * * * *"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -34,6 +34,7 @@ env:
   FEATURE_FLAG_OUTAGE_BANNER_ENABLED: false
   REDIS_ENABLED: true
   VLBEVENT_EXPORT_SPREADSHEET_ID: "1YUKHKsq9VftSLm6twO9F172gHDh6Xp8Tj6V1HEN6FbA"
+  MANAGE_USERS_API_URL: https://manage-users-api-preprod.hmpps.service.justice.gov.uk/
 
 jobs:
   cronspec: "59 * * * *"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -34,6 +34,7 @@ env:
   REDIS_ENABLED: true
   FEATURE_FLAG_OUTAGE_BANNER_ENABLED: false
   VLBEVENT_EXPORT_SPREADSHEET_ID: "1AsW6GH8pM3GYQthcLY-L5hi9Lf3RYvN9QNnpdGx9weM"
+  MANAGE_USERS_API_URL: https://manage-users-api.hmpps.service.justice.gov.uk/
 
 jobs:
   cronspec: "59 * * * *"

--- a/integration-tests/mockApis/auth.js
+++ b/integration-tests/mockApis/auth.js
@@ -96,7 +96,7 @@ const stubUser = username => {
   return stubFor({
     request: {
       method: 'GET',
-      urlPattern: `/auth/api/user/${encodeURI(user)}`,
+      urlPattern: `/users/${encodeURI(user)}`,
     },
     response: {
       status: 200,
@@ -119,7 +119,7 @@ const stubUserMe = ({ username = 'COURT_USER', staffId = 12345, name } = {}) => 
   return stubFor({
     request: {
       method: 'GET',
-      urlPattern: '/auth/api/user/me',
+      urlPattern: '/users/me',
     },
     response: {
       status: 200,
@@ -139,7 +139,7 @@ const stubUserMeRoles = (roles = ['ROLE']) =>
   stubFor({
     request: {
       method: 'GET',
-      url: '/auth/api/user/me/roles',
+      url: '/users/me/roles',
     },
     response: {
       status: 200,
@@ -154,7 +154,7 @@ const stubEmail = username =>
   stubFor({
     request: {
       method: 'GET',
-      url: `/auth/api/user/${encodeURI(username)}/email`,
+      url: `/users/${encodeURI(username)}/email`,
     },
     response: {
       status: 200,
@@ -172,7 +172,7 @@ const stubUnverifiedEmail = username =>
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: `/auth/api/user/${encodeURI(username)}/email`,
+      urlPattern: `/users/${encodeURI(username)}/email`,
     },
     response: {
       status: 204,


### PR DESCRIPTION
Use Manage Users API for user details/roles instead of deprecated HMPPS Auth endpoints

Ticket: [MAP-306](https://dsdmoj.atlassian.net/browse/MAP-306)

[MAP-306]: https://dsdmoj.atlassian.net/browse/MAP-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ