### PR TITLE
MAP-829 update dependencies to fix CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@ministryofjustice/frontend": "^1.6.6",
         "agentkeepalive": "^4.3.0",
         "applicationinsights": "^2.6.0",
-        "axios": "^1.4.0",
+        "axios": "^1.6.7",
         "bunyan": "^1.8.15",
         "bunyan-format": "^0.2.1",
         "connect-flash": "^0.1.1",
@@ -36,7 +36,7 @@
         "moment": "^2.29.4",
         "moment-business-days": "^1.2.0",
         "nocache": "^3.0.4",
-        "notifications-node-client": "^7.0.6",
+        "notifications-node-client": "^8.0.0",
         "nunjucks": "^3.2.4",
         "passport": "^0.6.0",
         "passport-oauth2": "^1.7.0",
@@ -45,7 +45,6 @@
         "superagent": "^8.0.9"
       },
       "devDependencies": {
-        "@types/axios": "^0.14.0",
         "@types/bunyan": "^1.8.8",
         "@types/cookie-parser": "^1.4.3",
         "@types/express": "^4.17.17",
@@ -1688,16 +1687,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@types/axios": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
-      "integrity": "sha512-KqQnQbdYE54D7oa/UmYVMZKq7CO4l8DEENzOKc4aBRwxCXSlJXGz83flFx5L7AWrOQnmuN3kVsRdt+GZPPjiVQ==",
-      "deprecated": "This is a stub types definition for axios (https://github.com/mzabriskie/axios). axios provides its own type definitions, so you don't need @types/axios installed!",
-      "dev": true,
-      "dependencies": {
-        "axios": "*"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
@@ -2626,11 +2615,11 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
-      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -5433,9 +5422,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -8762,9 +8751,9 @@
       }
     },
     "node_modules/notifications-node-client": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-7.0.6.tgz",
-      "integrity": "sha512-qo6eZMGdyaQnj/bkOnPb/d0a0sHIjiBzXlmICLPXYSD4pB3LYa537OhuZGuaFcSnkrM4NzbQhbQHAYX1NnbQgw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-8.0.0.tgz",
+      "integrity": "sha512-65BxorFYVFOpJ9c2lud/4Ju+Bfn3L/vkih+FuzMhBw1wcOPjwgu4doVH6xO91fHYiAi/0uIx0Mc+NorXeANMHw==",
       "dependencies": {
         "axios": "^1.6.1",
         "jsonwebtoken": "^9.0.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@ministryofjustice/frontend": "^1.6.6",
     "agentkeepalive": "^4.3.0",
     "applicationinsights": "^2.6.0",
-    "axios": "^1.4.0",
+    "axios": "^1.6.7",
     "bunyan": "^1.8.15",
     "bunyan-format": "^0.2.1",
     "connect-flash": "^0.1.1",
@@ -35,7 +35,7 @@
     "moment": "^2.29.4",
     "moment-business-days": "^1.2.0",
     "nocache": "^3.0.4",
-    "notifications-node-client": "^7.0.6",
+    "notifications-node-client": "^8.0.0",
     "nunjucks": "^3.2.4",
     "passport": "^0.6.0",
     "passport-oauth2": "^1.7.0",
@@ -44,7 +44,6 @@
     "superagent": "^8.0.9"
   },
   "devDependencies": {
-    "@types/axios": "^0.14.0",
     "@types/bunyan": "^1.8.8",
     "@types/cookie-parser": "^1.4.3",
     "@types/express": "^4.17.17",


### PR DESCRIPTION
to fix 'follow-redirects' which is a dependency of axios which is s dependency of notifications-node-client



Note @types/axios deprecated
see [this](https://www.npmjs.com/package/@types/axios)