### PR TITLE
MAP-932 changed bvl events data to be up to past 31 days only

### DIFF
--- a/backend/jobs/eventsJob.ts
+++ b/backend/jobs/eventsJob.ts
@@ -30,7 +30,7 @@ const pusher = new EventsPusher(
 )
 
 const job = async () => {
-  const events = await retriever.retrieveEventsForDay(moment())
+  const events = await retriever.retrieveEventsForPastMonth(moment().subtract(1, 'month'))
   await pusher.pushEvents(events)
 }
 

--- a/backend/jobs/eventsPusher.ts
+++ b/backend/jobs/eventsPusher.ts
@@ -39,15 +39,15 @@ export default class EventsPusher {
       logger.info(`EventsPusher: Finished. No events to push.`)
       return
     }
-    const firstRow = parseInt(events[0][0], 10)
-    const range = `A${firstRow + 1}`
+
     try {
+      await this.spreadsheets.values.clear({ range: 'A2' })
       const result = await this.spreadsheets.values.batchUpdate({
         spreadsheetId: this.spreadsheetId,
         requestBody: {
           data: [
             {
-              range,
+              range: 'A2',
               values: events,
             },
           ],

--- a/backend/jobs/eventsRetriever.test.ts
+++ b/backend/jobs/eventsRetriever.test.ts
@@ -26,7 +26,8 @@ describe('test', () => {
       return Promise.resolve()
     })
 
-    const events = await eventsRetriever.retrieveEventsForDay(moment('2021-07-01 09:01:01'))
+    const reportDate = moment('2021-07-01 09:01:01')
+    const events = await eventsRetriever.retrieveEventsForPastMonth(reportDate)
 
     expect(events).toStrictEqual([
       ['1', '2', '3'],
@@ -35,11 +36,8 @@ describe('test', () => {
 
     const call = whereaboutsApi.getVideoLinkEventsCSV.mock.calls[0]
     expect(call[0]).toStrictEqual(tokens)
-
-    expect(
-      moment({ year: 2021, month: 6, day: 1, hour: 0, minute: 0, seconds: 0, milliseconds: 0 }).isSame(call[2])
-    ).toBe(true)
-    expect(call[3]).toBe(1)
+    expect(reportDate.isSame(call[2])).toBe(true)
+    expect(call[3]).toBe(31)
   })
 
   it('Handles no events', async () => {
@@ -50,7 +48,7 @@ describe('test', () => {
       return Promise.resolve()
     })
 
-    const events = await eventsRetriever.retrieveEventsForDay(moment('2021-07-01'))
+    const events = await eventsRetriever.retrieveEventsForPastMonth(moment('2021-07-01'))
     expect(events).toStrictEqual([])
   })
 })

--- a/backend/jobs/eventsRetriever.ts
+++ b/backend/jobs/eventsRetriever.ts
@@ -15,7 +15,7 @@ export default class EventsRetriever {
     this.whereaboutsApi = whereaboutsApi
   }
 
-  async retrieveEventsForDay(day: Moment): Promise<string[][]> {
+  async retrieveEventsForPastMonth(date: Moment): Promise<string[][]> {
     const tokens = await this.tokenSource.getTokens()
     const parser = parse({
       delimiter: ',',
@@ -23,12 +23,12 @@ export default class EventsRetriever {
       from: 2,
     })
     const records: string[][] = []
-    this.whereaboutsApi.getVideoLinkEventsCSV(tokens, parser, day.startOf('day'), 1)
+    this.whereaboutsApi.getVideoLinkEventsCSV(tokens, parser, date, 31)
     // eslint-disable-next-line no-restricted-syntax
     for await (const record of parser) {
       records.push(record)
     }
-    logger.info(`Retrieved ${records.length} events for ${day}`)
+    logger.info(`Retrieved ${records.length} events from ${date}`)
     return records
   }
 }

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -37,4 +37,4 @@ env:
   MANAGE_USERS_API_URL: https://manage-users-api-dev.hmpps.service.justice.gov.uk/
 
 jobs:
-  cronspec: "59 * * * *"
+  cronspec: "0 8,12,15 * * *"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -37,7 +37,7 @@ env:
   MANAGE_USERS_API_URL: https://manage-users-api-preprod.hmpps.service.justice.gov.uk/
 
 jobs:
-  cronspec: "59 * * * *"
+  cronspec: "0 8,12,15 * * *"
 
 whitelist:
   cloudplatform-live1-1: 35.178.209.113/32

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -37,7 +37,7 @@ env:
   MANAGE_USERS_API_URL: https://manage-users-api.hmpps.service.justice.gov.uk/
 
 jobs:
-  cronspec: "59 * * * *"
+  cronspec: "0 8,12,15 * * *"
 
 whitelist:
   cloudplatform-live1-1: 35.178.209.113/32


### PR DESCRIPTION
Cron job was failing with an error indicating the spreadsheet limits had been exceeded. 
The job obtains data from whereabouts-api, pushes it to a google sheet which in turn is the source for Looker Studio. 

The current code converts eventId's into an integer and use that as a row reference on which to append the next set of data. The job ran every hour and updated the sheet with the current day's data. 

The evenId has reached hundreds of thousands so was trying to access a row near the limits of google sheets. (The limit is 10 million cells)

So I have changed the code so that 
- we don't use the eventId to reference the row from which to add the new data. Instead new data will be added from cell A2
- we only get the last months data (this is a test - may extend to past 2 months)
- replace any existing data by clearing the spreadsheet 
- run the cron job at 8am, 12pm and 3pm every day instead of every hour 