### PR TITLE
MAP-973 change the range to target all rows of google sheet starting …

### DIFF
--- a/backend/jobs/eventsPusher.ts
+++ b/backend/jobs/eventsPusher.ts
@@ -43,7 +43,7 @@ export default class EventsPusher {
     try {
       await this.spreadsheets.values.clear({
         spreadsheetId: this.spreadsheetId,
-        range: 'A2',
+        range: '2:384615',
         requestBody: {},
       })
       const result = await this.spreadsheets.values.batchUpdate({


### PR DESCRIPTION
…row 2

The cronjob is getting the right amount of data from whereabouts-api but when pushing that data to google sheets, some data is duplicated. Each time the cronjob runs, it should  clear the previous data in the google sheet then add the new batch. 
Have noticed that some lines are duplicated. Hoping that be referencing the rows as per this PR, every row will be cleared. 

see the 3rd example [here](https://developers.google.com/sheets/api/guides/concepts#expandable-1)

and the max number of rows [here](https://rowzero.io/blog/what-is-the-google-sheets-row-limit)